### PR TITLE
Space4x: add turn-based speed slowdown

### DIFF
--- a/Assets/Scripts/Space4x/Authoring/Space4XVesselMotionProfileAuthoring.cs
+++ b/Assets/Scripts/Space4x/Authoring/Space4XVesselMotionProfileAuthoring.cs
@@ -29,6 +29,10 @@ namespace Space4X.Authoring
         [Range(0.8f, 1.5f)] public float intelligentTurnMultiplier = 1.15f;
         [Range(0.5f, 1.2f)] public float intelligentSlowdownMultiplier = 0.9f;
 
+        [Header("Turn Behavior")]
+        [Tooltip("0 disables turn-based slowdown.")]
+        [Range(0f, 1f)] public float turnSlowdownFactor = 0f;
+
         [Header("Capital Ship Baseline")]
         [Range(0.3f, 1f)] public float capitalShipSpeedMultiplier = 0.85f;
         [Range(0.3f, 1f)] public float capitalShipTurnMultiplier = 0.8f;
@@ -65,6 +69,7 @@ namespace Space4X.Authoring
             chaoticDeviationMinDistance = math.max(0f, chaoticDeviationMinDistance);
             intelligentTurnMultiplier = math.clamp(intelligentTurnMultiplier, 0.8f, 1.5f);
             intelligentSlowdownMultiplier = math.clamp(intelligentSlowdownMultiplier, 0.5f, 1.2f);
+            turnSlowdownFactor = math.clamp(turnSlowdownFactor, 0f, 1f);
             capitalShipSpeedMultiplier = math.clamp(capitalShipSpeedMultiplier, 0.3f, 1f);
             capitalShipTurnMultiplier = math.clamp(capitalShipTurnMultiplier, 0.3f, 1f);
             capitalShipAccelerationMultiplier = math.clamp(capitalShipAccelerationMultiplier, 0.3f, 1f);
@@ -102,6 +107,7 @@ namespace Space4X.Authoring
                     ChaoticDeviationMinDistance = authoring.chaoticDeviationMinDistance,
                     IntelligentTurnMultiplier = authoring.intelligentTurnMultiplier,
                     IntelligentSlowdownMultiplier = authoring.intelligentSlowdownMultiplier,
+                    TurnSlowdownFactor = authoring.turnSlowdownFactor,
                     CapitalShipSpeedMultiplier = authoring.capitalShipSpeedMultiplier,
                     CapitalShipTurnMultiplier = authoring.capitalShipTurnMultiplier,
                     CapitalShipAccelerationMultiplier = authoring.capitalShipAccelerationMultiplier,

--- a/Assets/Scripts/Space4x/Runtime/VesselComponents.cs
+++ b/Assets/Scripts/Space4x/Runtime/VesselComponents.cs
@@ -192,6 +192,7 @@ namespace Space4X.Runtime
         public float ChaoticDeviationMinDistance;
         public float IntelligentTurnMultiplier;
         public float IntelligentSlowdownMultiplier;
+        public float TurnSlowdownFactor;
         public float CapitalShipSpeedMultiplier;
         public float CapitalShipTurnMultiplier;
         public float CapitalShipAccelerationMultiplier;
@@ -223,6 +224,7 @@ namespace Space4X.Runtime
             ChaoticDeviationMinDistance = 6f,
             IntelligentTurnMultiplier = 1.15f,
             IntelligentSlowdownMultiplier = 0.9f,
+            TurnSlowdownFactor = 0f,
             CapitalShipSpeedMultiplier = 0.85f,
             CapitalShipTurnMultiplier = 0.8f,
             CapitalShipAccelerationMultiplier = 0.75f,

--- a/Assets/Scripts/Space4x/Systems/AI/VesselMovementSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/AI/VesselMovementSystem.cs
@@ -728,6 +728,13 @@ namespace Space4X.Systems.AI
                     desiredSpeed *= 0.55f;
                     rotationMultiplier *= 0.7f;
                 }
+                var turnSlowdownFactor = MotionConfig.TurnSlowdownFactor;
+                if (turnSlowdownFactor > 0f)
+                {
+                    var forward = math.forward(transform.Rotation);
+                    var alignment = math.saturate((math.dot(forward, direction) + 1f) * 0.5f);
+                    desiredSpeed *= math.lerp(1f, alignment, turnSlowdownFactor);
+                }
                 if (distance <= arrivalDistance)
                 {
                     desiredSpeed = math.min(desiredSpeed, math.max(0.05f, baseSpeed * 0.2f));


### PR DESCRIPTION
# PR: space4x_turn_slowdown_v1

Title
- Space4x: add turn-based speed slowdown

Summary
- Add TurnSlowdownFactor to the vessel motion profile config and authoring (default off).
- Scale desired speed by heading alignment when the factor is enabled to soften sharp turns.

Testing
- Not run (per instructions).
