### PR TITLE
Space4x: add overshoot movement metric

### DIFF
--- a/Assets/Scripts/Space4x/Headless/Space4XHeadlessMovementDiagnosticsSystem.cs
+++ b/Assets/Scripts/Space4x/Headless/Space4XHeadlessMovementDiagnosticsSystem.cs
@@ -557,7 +557,7 @@ namespace Space4X.Headless
             if (hasDebug)
             {
                 var debug = SystemAPI.GetComponentRO<MovementDebugState>(entity).ValueRO;
-                UnityDebug.LogError($"[Space4XHeadlessMovementDiag] Debug lastPos={debug.LastPosition} lastDist={debug.LastDistanceToTarget:F2} lastSpeed={debug.LastSpeed:F2} maxSpeedDelta={debug.MaxSpeedDelta:F2} maxTeleport={debug.MaxTeleportDistance:F2} nanInf={debug.NaNInfCount} speedClamp={debug.SpeedClampCount} accelClamp={debug.AccelClampCount} teleport={debug.TeleportCount} stuck={debug.StuckCount} flips={debug.StateFlipCount} lastProgressTick={debug.LastProgressTick}");
+                UnityDebug.LogError($"[Space4XHeadlessMovementDiag] Debug lastPos={debug.LastPosition} lastDist={debug.LastDistanceToTarget:F2} lastSpeed={debug.LastSpeed:F2} maxSpeedDelta={debug.MaxSpeedDelta:F2} maxTeleport={debug.MaxTeleportDistance:F2} nanInf={debug.NaNInfCount} speedClamp={debug.SpeedClampCount} accelClamp={debug.AccelClampCount} overshoot={debug.OvershootCount} teleport={debug.TeleportCount} stuck={debug.StuckCount} flips={debug.StateFlipCount} lastProgressTick={debug.LastProgressTick}");
             }
 
             if (hasMiningState)

--- a/Assets/Scripts/Space4x/Registry/Space4XMovementTelemetrySystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XMovementTelemetrySystem.cs
@@ -84,6 +84,7 @@ namespace Space4X.Registry
             var nanInf = 0u;
             var speedClamp = 0u;
             var accelClampTotal = 0u;
+            var overshootTotal = 0u;
             var teleport = 0u;
             var stuck = 0u;
             var stateFlips = 0u;
@@ -96,6 +97,7 @@ namespace Space4X.Registry
                 nanInf += stateDebug.NaNInfCount;
                 speedClamp += stateDebug.SpeedClampCount;
                 accelClampTotal += stateDebug.AccelClampCount;
+                overshootTotal += stateDebug.OvershootCount;
                 teleport += stateDebug.TeleportCount;
                 stuck += stateDebug.StuckCount;
                 stateFlips += stateDebug.StateFlipCount;
@@ -119,6 +121,7 @@ namespace Space4X.Registry
             buffer.AddMetric("space4x.movement.naninf", nanInf, TelemetryMetricUnit.Count);
             buffer.AddMetric("space4x.movement.speedClamp", speedClamp, TelemetryMetricUnit.Count);
             buffer.AddMetric("space4x.movement.accelClamp", accelClampTotal, TelemetryMetricUnit.Count);
+            buffer.AddMetric("space4x.movement.overshoot", overshootTotal, TelemetryMetricUnit.Count);
             buffer.AddMetric("space4x.movement.teleport", teleport, TelemetryMetricUnit.Count);
             buffer.AddMetric("space4x.movement.stuck", stuck, TelemetryMetricUnit.Count);
             buffer.AddMetric("space4x.movement.stateFlips", stateFlips, TelemetryMetricUnit.Count);

--- a/Assets/Scripts/Space4x/Runtime/Space4XMovementDebugComponents.cs
+++ b/Assets/Scripts/Space4x/Runtime/Space4XMovementDebugComponents.cs
@@ -76,6 +76,7 @@ namespace Space4X.Runtime
         public uint NaNInfCount;
         public uint SpeedClampCount;
         public uint AccelClampCount;
+        public uint OvershootCount;
         public uint TeleportCount;
         public uint StuckCount;
         public uint StateFlipCount;

--- a/Assets/Scripts/Space4x/Systems/AI/VesselMovementSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/AI/VesselMovementSystem.cs
@@ -908,7 +908,7 @@ namespace Space4X.Systems.AI
                 UpdateMoveIntent(entity, aiState.TargetEntity, targetPosition, intentType, ref debugState, hasDebug);
                 UpdateMovePlan(entity, planMode, desiredVelocity, accelLimit, eta, ref debugState, hasDebug);
                 UpdateDecisionTrace(entity, DecisionReasonCode.Moving, aiState.TargetEntity, 1f, blockerEntity, ref debugState, hasDebug);
-                UpdateMovementInvariants(entity, transform.Position, distance, movement.CurrentSpeed, baseSpeed, ref debugState, hasDebug);
+                UpdateMovementInvariants(entity, transform.Position, distance, movement.CurrentSpeed, baseSpeed, slowdownDistance, ref debugState, hasDebug);
             }
 
             private BehaviorDisposition ResolveBehaviorDisposition(Entity profileEntity, Entity vesselEntity)
@@ -1262,7 +1262,7 @@ namespace Space4X.Systems.AI
                 }
             }
 
-            private void UpdateMovementInvariants(Entity entity, float3 position, float distanceToTarget, float currentSpeed, float baseSpeed, ref MovementDebugState debugState, bool hasDebug)
+            private void UpdateMovementInvariants(Entity entity, float3 position, float distanceToTarget, float currentSpeed, float baseSpeed, float slowdownDistance, ref MovementDebugState debugState, bool hasDebug)
             {
                 if (!hasDebug)
                 {
@@ -1291,6 +1291,10 @@ namespace Space4X.Systems.AI
 
                 var speedDelta = math.abs(currentSpeed - debugState.LastSpeed);
                 debugState.MaxSpeedDelta = math.max(debugState.MaxSpeedDelta, speedDelta);
+                if (slowdownDistance > 0f && distanceToTarget <= slowdownDistance && distanceToTarget > debugState.LastDistanceToTarget + 0.05f)
+                {
+                    debugState.OvershootCount += 1;
+                }
 
                 if (distanceToTarget + 0.05f < debugState.LastDistanceToTarget)
                 {


### PR DESCRIPTION
# PR: space4x_overshoot_metric_v1

Title
- Space4x: add overshoot movement metric

Summary
- Track overshoot when distance to target increases inside the slowdown window.
- Emit `space4x.movement.overshoot` and include the count in headless diagnostics.

Testing
- Not run (per instructions).
