### PR TITLE
Space4x: add retrograde boost

### DIFF
--- a/Assets/Scripts/Space4x/Authoring/Space4XVesselMotionProfileAuthoring.cs
+++ b/Assets/Scripts/Space4x/Authoring/Space4XVesselMotionProfileAuthoring.cs
@@ -29,6 +29,10 @@ namespace Space4X.Authoring
         [Range(0.8f, 1.5f)] public float intelligentTurnMultiplier = 1.15f;
         [Range(0.5f, 1.2f)] public float intelligentSlowdownMultiplier = 0.9f;
 
+        [Header("Retrograde")]
+        [Tooltip("0 disables retrograde weighting boost.")]
+        [Range(0f, 2f)] public float retrogradeBoost = 0f;
+
         [Header("Capital Ship Baseline")]
         [Range(0.3f, 1f)] public float capitalShipSpeedMultiplier = 0.85f;
         [Range(0.3f, 1f)] public float capitalShipTurnMultiplier = 0.8f;
@@ -65,6 +69,7 @@ namespace Space4X.Authoring
             chaoticDeviationMinDistance = math.max(0f, chaoticDeviationMinDistance);
             intelligentTurnMultiplier = math.clamp(intelligentTurnMultiplier, 0.8f, 1.5f);
             intelligentSlowdownMultiplier = math.clamp(intelligentSlowdownMultiplier, 0.5f, 1.2f);
+            retrogradeBoost = math.clamp(retrogradeBoost, 0f, 2f);
             capitalShipSpeedMultiplier = math.clamp(capitalShipSpeedMultiplier, 0.3f, 1f);
             capitalShipTurnMultiplier = math.clamp(capitalShipTurnMultiplier, 0.3f, 1f);
             capitalShipAccelerationMultiplier = math.clamp(capitalShipAccelerationMultiplier, 0.3f, 1f);
@@ -102,6 +107,7 @@ namespace Space4X.Authoring
                     ChaoticDeviationMinDistance = authoring.chaoticDeviationMinDistance,
                     IntelligentTurnMultiplier = authoring.intelligentTurnMultiplier,
                     IntelligentSlowdownMultiplier = authoring.intelligentSlowdownMultiplier,
+                    RetrogradeBoost = authoring.retrogradeBoost,
                     CapitalShipSpeedMultiplier = authoring.capitalShipSpeedMultiplier,
                     CapitalShipTurnMultiplier = authoring.capitalShipTurnMultiplier,
                     CapitalShipAccelerationMultiplier = authoring.capitalShipAccelerationMultiplier,

--- a/Assets/Scripts/Space4x/Runtime/VesselComponents.cs
+++ b/Assets/Scripts/Space4x/Runtime/VesselComponents.cs
@@ -192,6 +192,7 @@ namespace Space4X.Runtime
         public float ChaoticDeviationMinDistance;
         public float IntelligentTurnMultiplier;
         public float IntelligentSlowdownMultiplier;
+        public float RetrogradeBoost;
         public float CapitalShipSpeedMultiplier;
         public float CapitalShipTurnMultiplier;
         public float CapitalShipAccelerationMultiplier;
@@ -223,6 +224,7 @@ namespace Space4X.Runtime
             ChaoticDeviationMinDistance = 6f,
             IntelligentTurnMultiplier = 1.15f,
             IntelligentSlowdownMultiplier = 0.9f,
+            RetrogradeBoost = 0f,
             CapitalShipSpeedMultiplier = 0.85f,
             CapitalShipTurnMultiplier = 0.8f,
             CapitalShipAccelerationMultiplier = 0.75f,

--- a/Assets/Scripts/Space4x/Systems/AI/VesselMovementSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/AI/VesselMovementSystem.cs
@@ -772,6 +772,11 @@ namespace Space4X.Systems.AI
 
                     if (retrogradeWeight > 0f)
                     {
+                        var retrogradeBoost = MotionConfig.RetrogradeBoost;
+                        if (retrogradeBoost > 0f)
+                        {
+                            retrogradeWeight = math.saturate(retrogradeWeight * (1f + retrogradeBoost));
+                        }
                         var retroDir = math.normalizesafe(-movement.Velocity, direction);
                         var retroVelocity = retroDir * desiredSpeed;
                         desiredVelocity = math.lerp(desiredVelocity, retroVelocity, retrogradeWeight);


### PR DESCRIPTION
# PR: space4x_retrograde_boost_v1

Title
- Space4x: add retrograde weighting boost

Summary
- Add RetrogradeBoost to vessel motion profile config and authoring (default off).
- Scale retrograde blending weight when enabled to favor braking direction sooner.

Testing
- Not run (per instructions).
