### PR TITLE
Space4x asteroid dig headless gate

### DIFF
--- a/Assets/Scenarios/asteroid_dig_01.json
+++ b/Assets/Scenarios/asteroid_dig_01.json
@@ -1,0 +1,49 @@
+{
+  "seed": 8128,
+  "duration_s": 3045,
+  "spawn": [
+    {
+      "kind": "Carrier",
+      "entityId": "carrier-1",
+      "position": [0, -10, 0],
+      "components": {
+        "ResourceStorage": [
+          {"type": "Minerals", "capacity": 10000}
+        ]
+      }
+    },
+    {
+      "kind": "MiningVessel",
+      "entityId": "miner-1",
+      "position": [0, -5, 0],
+      "carrierId": "carrier-1",
+      "toolKind": "drill",
+      "toolShape": "brush",
+      "toolShapeOverride": true,
+      "toolRadiusOverride": 1.25,
+      "toolStepLengthOverride": 0.9,
+      "resourceId": "Minerals",
+      "miningEfficiency": 0.85,
+      "speed": 5.0,
+      "cargoCapacity": 120.0
+    },
+    {
+      "kind": "ResourceDeposit",
+      "entityId": "deposit-1",
+      "position": [0, 15, 0],
+      "resourceId": "Minerals",
+      "unitsRemaining": 1200.0,
+      "gatherRatePerWorker": 12.0,
+      "maxSimultaneousWorkers": 1
+    }
+  ],
+  "actions": [],
+  "telemetryExpectations": {
+    "expectMiningYield": true,
+    "expectCarrierPickup": true,
+    "export": {
+      "csv": "Reports/asteroid_dig_01_metrics.csv",
+      "json": "Reports/asteroid_dig_01_metrics.json"
+    }
+  }
+}

--- a/Assets/Scenarios/asteroid_dig_01.json.meta
+++ b/Assets/Scenarios/asteroid_dig_01.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 996e671729984bf49c6dab23facb6804
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Space4x/Headless/Space4XHeadlessAsteroidDigGateSystem.cs
+++ b/Assets/Scripts/Space4x/Headless/Space4XHeadlessAsteroidDigGateSystem.cs
@@ -1,0 +1,110 @@
+using System.Globalization;
+using System.IO;
+using PureDOTS.Environment;
+using PureDOTS.Runtime.Components;
+using PureDOTS.Runtime.Core;
+using PureDOTS.Runtime.Time;
+using Space4x.Scenario;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Space4X.Headless
+{
+    [UpdateInGroup(typeof(LateSimulationSystemGroup))]
+    [UpdateAfter(typeof(PureDOTS.Systems.Telemetry.TelemetryExportSystem))]
+    [UpdateBefore(typeof(PureDOTS.Systems.HeadlessExitSystem))]
+    public partial struct Space4XHeadlessAsteroidDigGateSystem : ISystem
+    {
+        private const string SessionDirEnv = "SPACE4X_DIG_GATE_SESSION_DIR";
+        private const string DefaultSessionDir = @"C:\polish\queue\reports\session_20260108_workblock";
+        private const string SummaryFileName = "asteroid_dig_gate_summary.json";
+
+        private byte _done;
+        private string _summaryPath;
+
+        public void OnCreate(ref SystemState state)
+        {
+            if (!RuntimeMode.IsHeadless || !Application.isBatchMode)
+            {
+                state.Enabled = false;
+                return;
+            }
+
+            state.RequireForUpdate<TimeState>();
+            state.RequireForUpdate<Space4XScenarioRuntime>();
+            state.RequireForUpdate<TerrainModificationQueue>();
+
+            var sessionDir = System.Environment.GetEnvironmentVariable(SessionDirEnv);
+            if (string.IsNullOrWhiteSpace(sessionDir))
+            {
+                sessionDir = DefaultSessionDir;
+            }
+
+            _summaryPath = Path.Combine(Path.GetFullPath(sessionDir), SummaryFileName);
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            if (_done != 0)
+            {
+                return;
+            }
+
+            var timeState = SystemAPI.GetSingleton<TimeState>();
+            var scenario = SystemAPI.GetSingleton<Space4XScenarioRuntime>();
+            if (timeState.Tick < scenario.EndTick)
+            {
+                return;
+            }
+
+            _done = 1;
+
+            var digOccurred = false;
+            if (SystemAPI.TryGetSingletonEntity<TerrainModificationQueue>(out var queueEntity) &&
+                state.EntityManager.HasBuffer<TerrainModificationEvent>(queueEntity))
+            {
+                var events = state.EntityManager.GetBuffer<TerrainModificationEvent>(queueEntity);
+                for (int i = 0; i < events.Length; i++)
+                {
+                    if (events[i].ClearedVoxels > 0)
+                    {
+                        digOccurred = true;
+                        break;
+                    }
+                }
+            }
+
+            if (digOccurred)
+            {
+                return;
+            }
+
+            WriteFailureSummary(timeState.Tick);
+            HeadlessExitUtility.Request(state.EntityManager, timeState.Tick, Space4XHeadlessDiagnostics.TestFailExitCode);
+        }
+
+        private void WriteFailureSummary(uint tick)
+        {
+            if (string.IsNullOrWhiteSpace(_summaryPath))
+            {
+                return;
+            }
+
+            try
+            {
+                var dir = Path.GetDirectoryName(_summaryPath);
+                if (!string.IsNullOrWhiteSpace(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                var json = "{\"status\":\"FAIL\",\"reason\":\"NO_TERRAIN_DIG\",\"tick\":" +
+                           tick.ToString(CultureInfo.InvariantCulture) + "}";
+                File.WriteAllText(_summaryPath, json);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Headless/Space4XHeadlessAsteroidDigGateSystem.cs.meta
+++ b/Assets/Scripts/Space4x/Headless/Space4XHeadlessAsteroidDigGateSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ddb950db3bfc43f4bee7b7f419596e9f


### PR DESCRIPTION
Title: Space4x asteroid dig headless gate

Summary:
- Add headless gate system that fails when no terrain dig events occur by scenario end.
- Add asteroid_dig_01 scenario for dig validation.

Validation (2026-01-11):
- Repeat1 smoke: TEST_FAIL (determinism_hash=749588bf602a65ee7859174d000a8f073dfe7910ca4c3ffe110e2455d1a8379b; result_zip=C:\polish\queue_pr13\results\result_20260111_043258_568_8f9d810f_space4x_77.zip)
- Repeat3 asteroid_dig_01: TEST_FAIL (determinism_hash=1e64885bf539fd4ec06012d161e00f90f826a05fa2a46bc698c51852bc47c697; result_zips=C:\polish\queue_pr13\results\result_20260111_043258_568_8f9d810f_space4x_8128_r01.zip; C:\polish\queue_pr13\results\result_20260111_043258_568_8f9d810f_space4x_8128_r02.zip; C:\polish\queue_pr13\results\result_20260111_043258_568_8f9d810f_space4x_8128_r03.zip)
- Artifact zip (entrypoint ok): C:\polish\queue_pr13\artifacts\artifact_20260111_043258_568_8f9d810f.zip
- Artifact entrypoint: build/Space4X_Headless.x86_64

Notes:
- Repeat runs failed invariant TurnAccel (exit_reason=TEST_FAIL).