### PR TITLE
Add source-available non-commercial license (attribution)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Contributing
+
+Thanks for your interest.
+
+By submitting a contribution (pull request, patch, or other code/doc change), you agree that:
+1) Your contribution is provided under the repository LICENSE (Non-Commercial, Attribution Required).
+2) You additionally grant MoniVibe a perpetual, worldwide, irrevocable right to use your contribution,
+   including the right to relicense it under separate terms (including commercial terms) for the purpose
+   of distributing or commercializing the project.
+3) You represent that you have the right to submit the contribution and that it does not violate any
+   third-party rights.
+
+If you are unable to grant these rights, do not submit a contribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+MoniVibe Source-Available License (Non-Commercial, Attribution Required) v1.0
+
+Copyright (c) 2026 MoniVibe
+All rights reserved.
+
+Permission is granted to any person to obtain a copy of this repositorys contents for personal use,
+learning, evaluation, and other NON-COMMERCIAL purposes, and to copy, modify, and redistribute
+the contents under the following conditions:
+
+1) Non-Commercial Use Only
+   You may not use the repository contents (in whole or in part) for any commercial purpose.
+   Commercial purpose includes selling, licensing, offering as a paid service, using in a product
+   or service for commercial advantage, or internal use at a for-profit company beyond evaluation.
+
+2) Attribution Required on Redistribution
+   If you redistribute the repository contents (modified or unmodified), you must:
+   - retain this LICENSE file and all copyright notices,
+   - provide attribution to MoniVibe and a link to the original repository,
+   - clearly mark that you have modified the work (if you did).
+
+3) No Trademark License
+   This license does not grant any rights in any names, logos, or trademarks (see TRADEMARKS.md).
+
+4) Third-Party Components
+   Third-party dependencies, libraries, Unity packages, assets, fonts, or tools included in this repository
+   may be governed by their own licenses. This license applies only to MoniVibe-authored content.
+   See THIRD_PARTY_NOTICES.md and license files located alongside third-party components.
+
+5) Termination
+   Any violation of this license automatically terminates your rights under this license.
+
+NO WARRANTY
+THE WORK IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY.
+
+Commercial Licensing
+If you want to use this work commercially, contact MoniVibe to obtain a commercial license.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+License
+- Source-available, non-commercial, redistribution allowed with attribution.
+- Commercial use requires a separate license. See LICENSE.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,6 @@
+Third-Party Notices
+
+This repository may include third-party components (Unity packages, fonts, sample assets, tools).
+Third-party components remain under their respective licenses found within the repository (often
+alongside the component under Assets/, Packages/, Tools/, etc.). This notice file is a place to track
+notable attributions as needed.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,5 @@
+MoniVibe Trademarks
+
+MoniVibe, PureDOTS, Godgame, Space4x, and associated names, logos, and branding are
+trademarks/brand identifiers of MoniVibe. No trademark rights are granted under the LICENSE.
+Do not use these marks to imply endorsement or affiliation.


### PR DESCRIPTION
- Adds LICENSE + TRADEMARKS + third-party notices + contributing terms\n- Notes: third-party assets retain their own licenses; this license applies to MoniVibe-authored code/docs.