### PR TITLE
Fleetcrawl: add emergency heat ejection with supplies/shard cost

### DIFF
--- a/Assets/Scripts/Space4x/Registry/Space4XCombatSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XCombatSystem.cs
@@ -309,6 +309,7 @@ namespace Space4X.Registry
                     _fleetcrawlHeatActionLookup.HasBuffer(entity);
 
                 var fleetcrawlHeatOutput = default(FleetcrawlHeatOutputState);
+                var emergencyVentFireLocked = false;
                 if (fleetcrawlHeatActive)
                 {
                     var runtime = _fleetcrawlHeatRuntimeLookup[entity];
@@ -319,6 +320,7 @@ namespace Space4X.Registry
                     {
                         var control = _fleetcrawlHeatControlLookup[entity];
                         safetyMode = control.SafetyMode;
+                        emergencyVentFireLocked = FleetcrawlHeatResolver.IsEmergencyVentFireLocked(control, currentTick);
                         if (control.HeatsinkEnabled == 0)
                         {
                             heatsink.BaseCapacity = 0f;
@@ -432,6 +434,15 @@ namespace Space4X.Registry
                     }
 
                     if (fleetcrawlHeatActive && FleetcrawlHeatResolver.ShouldSuppressFire(fleetcrawlHeatOutput))
+                    {
+                        if (mountDirty)
+                        {
+                            weaponBuffer[i] = mount;
+                        }
+                        continue;
+                    }
+
+                    if (emergencyVentFireLocked)
                     {
                         if (mountDirty)
                         {


### PR DESCRIPTION
## Summary
- add emergency heat ejection contracts/config for Fleetcrawl heat runtime
- add deterministic vent math helpers (dump amount, apply vent, supplies cost, shard fallback cost)
- add auto-request system for player ships under high heat/overheat
- add vent execution system that spends generic supplies (`RunCurrency`) and falls back to shard material (`Space4XRunMetaResourceState.Shards`) when enabled
- enforce short post-vent fire lock window in `Space4XWeaponSystem`
- add tests for emergency vent helper behavior

## Economy model
- primary spend: generic supplies
- secondary spend: shard-like rare material fallback ("silver-like")

## Scope boundary
- all changes are game-side (`Assets/Scripts/Space4x/...`)
- no `PureDOTS` logic moved or modified

## Validation
- iterator mode: no local laptop test execution
- request validator/buildbox validation for this PR
