### PR TITLE
Fleetcrawl combat: weapon-family heat, ordnance, and plasma falloff

### DIFF
--- a/Assets/Scripts/Space4x/Authoring/Physics/Space4XRockAuthoring.cs
+++ b/Assets/Scripts/Space4x/Authoring/Physics/Space4XRockAuthoring.cs
@@ -90,6 +90,10 @@ namespace Space4X.Authoring
         [Tooltip("Material density (for mass calculations). Rock: 3.0, Ship: 2.0, Soft: 0.8")]
         public float density = 3f;
 
+        [Header("Impact Physics")]
+        [Tooltip("Authored impact mass used by collision damage math when body is kinematic.")]
+        [Min(0.05f)] public float impactMass = 3f;
+
         [Header("Priority")]
         [Tooltip("Physics processing priority (0-255)")]
         [Range(0, 255)]
@@ -217,7 +221,7 @@ namespace Space4X.Authoring
             // Add PhysicsInteractionConfig
             AddComponent(entity, new PhysicsInteractionConfig
             {
-                Mass = 1f, // Kinematic, mass doesn't matter
+                Mass = math.max(0.05f, authoring.impactMass),
                 CollisionRadius = authoring.radius,
                 Restitution = 0f,
                 Friction = 0f,
@@ -237,4 +241,3 @@ namespace Space4X.Authoring
         }
     }
 }
-

--- a/Assets/Scripts/Space4x/Authoring/Physics/Space4XVesselPhysicsAuthoring.cs
+++ b/Assets/Scripts/Space4x/Authoring/Physics/Space4XVesselPhysicsAuthoring.cs
@@ -59,6 +59,10 @@ namespace Space4X.Authoring
         [Tooltip("Material density (for mass calculations). Rock: 3.0, Ship: 2.0, Soft: 0.8")]
         public float density = 2f;
 
+        [Header("Impact Physics")]
+        [Tooltip("Authored impact mass used by collision damage math when body is kinematic.")]
+        [Min(0.05f)] public float impactMass = 8f;
+
         [Header("Priority")]
         [Tooltip("Physics processing priority (0-255, higher = more important)")]
         [Range(0, 255)]
@@ -149,7 +153,7 @@ namespace Space4X.Authoring
             // Add PhysicsInteractionConfig
             AddComponent(entity, new PhysicsInteractionConfig
             {
-                Mass = 1f, // Kinematic, mass doesn't matter
+                Mass = math.max(0.05f, authoring.impactMass),
                 CollisionRadius = authoring.radius,
                 Restitution = 0f,
                 Friction = 0f,

--- a/Assets/Scripts/Space4x/Camera/Space4XCameraHudOverlay.cs
+++ b/Assets/Scripts/Space4x/Camera/Space4XCameraHudOverlay.cs
@@ -92,6 +92,11 @@ namespace Space4X.Camera
             public int TelegraphNormalBurst;
             public int TelegraphMiniBurst;
             public int TelegraphBossBurst;
+            public FixedString64Bytes FleetcrawlStartingCaptainProfileId;
+            public int FleetcrawlStartingCaptainPoolSize;
+            public Space4XRunMetaUnlockFlags FleetcrawlStartingCaptainUnlockFlags;
+            public bool FleetcrawlStartingCaptainForced;
+            public bool FleetcrawlStartingCaptainRandom;
             public float PersistentThrustGeneratedTotal;
             public uint PersistentMissilesFiredTotal;
             public uint PersistentKineticAmmoSpentTotal;
@@ -177,6 +182,9 @@ namespace Space4X.Camera
                     _labelStyle);
                 GUILayout.Label(
                     $"Challenge {_snapshot.FleetcrawlChallengeKind} risk={_snapshot.FleetcrawlChallengeRisk} spawn={_snapshot.FleetcrawlChallengeSpawnMultiplier:0.00}x xp={_snapshot.FleetcrawlChallengeExperienceMultiplier:0.00}x currency={_snapshot.FleetcrawlChallengeCurrencyMultiplier:0.00}x",
+                    _labelStyle);
+                GUILayout.Label(
+                    $"Captain {_snapshot.FleetcrawlStartingCaptainProfileId} pool={_snapshot.FleetcrawlStartingCaptainPoolSize} forced={(_snapshot.FleetcrawlStartingCaptainForced ? 1 : 0)} random={(_snapshot.FleetcrawlStartingCaptainRandom ? 1 : 0)} unlock_flags={_snapshot.FleetcrawlStartingCaptainUnlockFlags}",
                     _labelStyle);
                 GUILayout.Label(BuildFleetcrawlObjectiveText(in _snapshot), _labelStyle);
                 GUILayout.Label(
@@ -347,6 +355,15 @@ namespace Space4X.Camera
                         snapshot.FleetcrawlChallengeSpawnMultiplier = challenge.SpawnMultiplier;
                         snapshot.FleetcrawlChallengeCurrencyMultiplier = challenge.CurrencyMultiplier;
                         snapshot.FleetcrawlChallengeExperienceMultiplier = challenge.ExperienceMultiplier;
+                    }
+                    if (entityManager.HasComponent<Space4XRunStartingCaptainState>(directorEntity))
+                    {
+                        var captain = entityManager.GetComponentData<Space4XRunStartingCaptainState>(directorEntity);
+                        snapshot.FleetcrawlStartingCaptainProfileId = captain.ProfileId;
+                        snapshot.FleetcrawlStartingCaptainPoolSize = captain.CandidatePoolSize;
+                        snapshot.FleetcrawlStartingCaptainUnlockFlags = captain.UnlockFlags;
+                        snapshot.FleetcrawlStartingCaptainForced = captain.ForcedSelection != 0;
+                        snapshot.FleetcrawlStartingCaptainRandom = captain.RandomSelection != 0;
                     }
                 }
             }

--- a/Assets/Scripts/Space4x/Camera/Space4XCameraHudOverlay.cs
+++ b/Assets/Scripts/Space4x/Camera/Space4XCameraHudOverlay.cs
@@ -68,6 +68,15 @@ namespace Space4X.Camera
             public int FleetcrawlExperienceToNext;
             public int FleetcrawlUnspentUpgrades;
             public int FleetcrawlMetaShards;
+            public int FleetcrawlMetaUnlocks;
+            public float FleetcrawlMetaDamageDealt;
+            public float FleetcrawlMetaDamageMitigated;
+            public float FleetcrawlMetaCloakSeconds;
+            public float FleetcrawlMetaTimeStopSeconds;
+            public float FleetcrawlMetaMissileDamage;
+            public int FleetcrawlMetaCraftShotDown;
+            public int FleetcrawlMetaCapitalKills;
+            public int FleetcrawlMetaCachesFound;
             public Space4XFleetcrawlChallengeKind FleetcrawlChallengeKind;
             public int FleetcrawlChallengeRisk;
             public float FleetcrawlChallengeSpawnMultiplier;
@@ -149,6 +158,12 @@ namespace Space4X.Camera
                     _labelStyle);
                 GUILayout.Label(
                     $"Progress lvl={_snapshot.FleetcrawlLevel} xp={_snapshot.FleetcrawlExperience}/{_snapshot.FleetcrawlExperienceToNext} unspent={_snapshot.FleetcrawlUnspentUpgrades} shards={_snapshot.FleetcrawlMetaShards}",
+                    _labelStyle);
+                GUILayout.Label(
+                    $"Meta unlocks={_snapshot.FleetcrawlMetaUnlocks} dealt={_snapshot.FleetcrawlMetaDamageDealt:0} mitigated={_snapshot.FleetcrawlMetaDamageMitigated:0} cloak={_snapshot.FleetcrawlMetaCloakSeconds:0.0}s stop={_snapshot.FleetcrawlMetaTimeStopSeconds:0.0}s",
+                    _labelStyle);
+                GUILayout.Label(
+                    $"Meta ordnance={_snapshot.FleetcrawlMetaMissileDamage:0} craft={_snapshot.FleetcrawlMetaCraftShotDown} capital={_snapshot.FleetcrawlMetaCapitalKills} caches={_snapshot.FleetcrawlMetaCachesFound}",
                     _labelStyle);
                 GUILayout.Label(
                     $"Challenge {_snapshot.FleetcrawlChallengeKind} risk={_snapshot.FleetcrawlChallengeRisk} spawn={_snapshot.FleetcrawlChallengeSpawnMultiplier:0.00}x xp={_snapshot.FleetcrawlChallengeExperienceMultiplier:0.00}x currency={_snapshot.FleetcrawlChallengeCurrencyMultiplier:0.00}x",
@@ -273,6 +288,35 @@ namespace Space4X.Camera
                     {
                         var meta = entityManager.GetComponentData<Space4XRunMetaResourceState>(directorEntity);
                         snapshot.FleetcrawlMetaShards = meta.Shards;
+                    }
+                    if (entityManager.HasComponent<Space4XRunMetaUnlockState>(directorEntity))
+                    {
+                        var metaUnlocks = entityManager.GetComponentData<Space4XRunMetaUnlockState>(directorEntity);
+                        snapshot.FleetcrawlMetaUnlocks = metaUnlocks.UnlockCount;
+                    }
+                    if (entityManager.HasComponent<Space4XRunMetaProficiencyState>(directorEntity))
+                    {
+                        var metaProficiency = entityManager.GetComponentData<Space4XRunMetaProficiencyState>(directorEntity);
+                        snapshot.FleetcrawlMetaDamageDealt = metaProficiency.DamageDealtEnergy +
+                                                            metaProficiency.DamageDealtThermal +
+                                                            metaProficiency.DamageDealtEM +
+                                                            metaProficiency.DamageDealtRadiation +
+                                                            metaProficiency.DamageDealtCaustic +
+                                                            metaProficiency.DamageDealtKinetic +
+                                                            metaProficiency.DamageDealtExplosive;
+                        snapshot.FleetcrawlMetaDamageMitigated = metaProficiency.DamageMitigatedEnergy +
+                                                                metaProficiency.DamageMitigatedThermal +
+                                                                metaProficiency.DamageMitigatedEM +
+                                                                metaProficiency.DamageMitigatedRadiation +
+                                                                metaProficiency.DamageMitigatedCaustic +
+                                                                metaProficiency.DamageMitigatedKinetic +
+                                                                metaProficiency.DamageMitigatedExplosive;
+                        snapshot.FleetcrawlMetaCloakSeconds = metaProficiency.CloakSeconds;
+                        snapshot.FleetcrawlMetaTimeStopSeconds = metaProficiency.TimeStopRequestedSeconds;
+                        snapshot.FleetcrawlMetaMissileDamage = metaProficiency.MissileDamageDealt;
+                        snapshot.FleetcrawlMetaCraftShotDown = metaProficiency.CraftShotDown;
+                        snapshot.FleetcrawlMetaCapitalKills = metaProficiency.CapitalShipsDestroyed;
+                        snapshot.FleetcrawlMetaCachesFound = metaProficiency.HiddenCachesFound;
                     }
                     if (entityManager.HasComponent<Space4XRunChallengeState>(directorEntity))
                     {

--- a/Assets/Scripts/Space4x/Camera/Space4XCameraHudOverlay.cs
+++ b/Assets/Scripts/Space4x/Camera/Space4XCameraHudOverlay.cs
@@ -1,4 +1,5 @@
 using PureDOTS.Runtime.Components;
+using Space4X.Input;
 using Space4X.Progression;
 using Space4X.BattleSlice;
 using Space4x.Scenario;
@@ -95,6 +96,7 @@ namespace Space4X.Camera
             public uint PersistentMissilesFiredTotal;
             public uint PersistentKineticAmmoSpentTotal;
             public bool HasPersistentProgression;
+            public bool RtsAttackMovePrimed;
         }
 
         private void OnEnable()
@@ -187,6 +189,10 @@ namespace Space4X.Camera
                 GUILayout.Label(
                     $"Retained progression thrust={_snapshot.PersistentThrustGeneratedTotal:0.0} missiles={_snapshot.PersistentMissilesFiredTotal} kinetic_ammo={_snapshot.PersistentKineticAmmoSpentTotal}",
                     _labelStyle);
+            }
+            if (_snapshot.RtsAttackMovePrimed)
+            {
+                GUILayout.Label("RTS attack-move primed (A): left click to issue", _labelStyle);
             }
 
             var mode = _rigController != null && _rigController.IsCinematicActive
@@ -381,6 +387,8 @@ namespace Space4X.Camera
                 snapshot.PersistentKineticAmmoSpentTotal = persistent.TotalKineticAmmoSpent;
                 snapshot.HasPersistentProgression = true;
             }
+
+            snapshot.RtsAttackMovePrimed = Space4XRtsClassicCommandMono.IsAttackMovePrimed;
 
             _snapshot = snapshot;
         }

--- a/Assets/Scripts/Space4x/Diagnostics/Space4XPresentationBootstrapOverride.cs
+++ b/Assets/Scripts/Space4x/Diagnostics/Space4XPresentationBootstrapOverride.cs
@@ -10,6 +10,13 @@ namespace Space4X.Diagnostics
     {
         private const string SmokeSceneName = "TRI_Space4X_Smoke";
         private const string ForceRenderEnvVar = "PUREDOTS_FORCE_RENDER";
+        private const string LaptopValidationProbeMarker = "[Space4X Laptop Probe 2026-02-21T07:10Z]";
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void EmitLaptopValidationProbe()
+        {
+            Debug.Log($"{LaptopValidationProbeMarker} checkout reached editor domain reload.");
+        }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void EnsurePresentationForSmokeScene()

--- a/Assets/Scripts/Space4x/Fleetcrawl/Space4XFleetcrawlHeatContracts.cs
+++ b/Assets/Scripts/Space4x/Fleetcrawl/Space4XFleetcrawlHeatContracts.cs
@@ -385,6 +385,15 @@ namespace Space4x.Fleetcrawl
             return merged;
         }
 
+        public static float ResolveHeatSignature01(in FleetcrawlHeatOutputState heatOutput)
+        {
+            var heat01 = math.saturate(heatOutput.Heat01);
+            var heatsinkFill01 = heatOutput.HeatsinkCapacity > 1e-5f
+                ? math.saturate(heatOutput.HeatsinkStoredHeat / heatOutput.HeatsinkCapacity)
+                : 0f;
+            return math.saturate(heat01 + heatsinkFill01 * 0.35f + (heatOutput.IsOverheated != 0 ? 0.2f : 0f));
+        }
+
         public static bool ShouldSuppressFire(in FleetcrawlHeatOutputState output)
         {
             return output.SuppressFire != 0;

--- a/Assets/Scripts/Space4x/Input/Space4XRtsClassicCommandMono.cs
+++ b/Assets/Scripts/Space4x/Input/Space4XRtsClassicCommandMono.cs
@@ -1,0 +1,161 @@
+using PureDOTS.Input;
+using PureDOTS.Runtime.Core;
+using Space4X.UI;
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+
+namespace Space4X.Input
+{
+    /// <summary>
+    /// Adds classic RTS command ergonomics for mode 3:
+    /// press A to prime attack-move, then left-click to issue.
+    /// </summary>
+    [DefaultExecutionOrder(-875)]
+    [DisallowMultipleComponent]
+    public sealed class Space4XRtsClassicCommandMono : MonoBehaviour
+    {
+        [SerializeField] private Key attackMoveKey = Key.A;
+        [SerializeField] private int playerId = 0;
+        [SerializeField] private bool requireRtsControlMode = true;
+
+        private World _world;
+        private EntityManager _entityManager;
+        private EntityQuery _rtsInputQuery;
+        private bool _queryReady;
+
+        public static bool IsAttackMovePrimed { get; private set; }
+
+        private void OnDisable()
+        {
+            DisposeQuery();
+            _world = null;
+            IsAttackMovePrimed = false;
+        }
+
+        private void Update()
+        {
+            if (!RuntimeMode.IsRenderingEnabled)
+            {
+                IsAttackMovePrimed = false;
+                return;
+            }
+
+            var keyboard = Keyboard.current;
+            var mouse = Mouse.current;
+            if (keyboard == null || mouse == null)
+            {
+                return;
+            }
+
+            if (requireRtsControlMode && Space4XControlModeState.CurrentMode != Space4XControlMode.Rts)
+            {
+                IsAttackMovePrimed = false;
+                return;
+            }
+
+            if (keyboard.escapeKey.wasPressedThisFrame || mouse.rightButton.wasPressedThisFrame)
+            {
+                IsAttackMovePrimed = false;
+            }
+
+            if (keyboard[attackMoveKey].wasPressedThisFrame && !IsPointerOverUi())
+            {
+                IsAttackMovePrimed = true;
+            }
+
+            if (!IsAttackMovePrimed || !mouse.leftButton.wasPressedThisFrame)
+            {
+                return;
+            }
+
+            if (IsPointerOverUi())
+            {
+                return;
+            }
+
+            if (!TryGetInputEntity(out var inputEntity))
+            {
+                return;
+            }
+
+            if (!_entityManager.HasBuffer<RightClickEvent>(inputEntity))
+            {
+                _entityManager.AddBuffer<RightClickEvent>(inputEntity);
+            }
+
+            var events = _entityManager.GetBuffer<RightClickEvent>(inputEntity);
+            var screenPos = mouse.position.ReadValue();
+            var queue = keyboard.leftShiftKey.isPressed || keyboard.rightShiftKey.isPressed;
+
+            events.Add(new RightClickEvent
+            {
+                ScreenPos = new float2(screenPos.x, screenPos.y),
+                Queue = (byte)(queue ? 1 : 0),
+                Ctrl = 1,
+                PlayerId = (byte)math.clamp(playerId, 0, 255),
+                HasWorldPoint = 0,
+                WorldPoint = float3.zero,
+                HasHitEntity = 0,
+                HitEntity = Entity.Null
+            });
+
+            IsAttackMovePrimed = false;
+        }
+
+        private bool TryGetInputEntity(out Entity inputEntity)
+        {
+            inputEntity = Entity.Null;
+            if (!TryEnsureQuery())
+            {
+                return false;
+            }
+
+            if (_rtsInputQuery.IsEmptyIgnoreFilter)
+            {
+                return false;
+            }
+
+            inputEntity = _rtsInputQuery.GetSingletonEntity();
+            return inputEntity != Entity.Null;
+        }
+
+        private bool TryEnsureQuery()
+        {
+            var world = World.DefaultGameObjectInjectionWorld;
+            if (world == null || !world.IsCreated)
+            {
+                return false;
+            }
+
+            if (_queryReady && world == _world)
+            {
+                return true;
+            }
+
+            DisposeQuery();
+            _world = world;
+            _entityManager = world.EntityManager;
+            _rtsInputQuery = _entityManager.CreateEntityQuery(ComponentType.ReadOnly<RtsInputSingletonTag>());
+            _queryReady = true;
+            return true;
+        }
+
+        private void DisposeQuery()
+        {
+            if (_queryReady)
+            {
+                _rtsInputQuery.Dispose();
+                _queryReady = false;
+            }
+        }
+
+        private static bool IsPointerOverUi()
+        {
+            var eventSystem = EventSystem.current;
+            return eventSystem != null && eventSystem.IsPointerOverGameObject();
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Input/Space4XRtsClassicCommandMono.cs.meta
+++ b/Assets/Scripts/Space4x/Input/Space4XRtsClassicCommandMono.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 270d05cc464a4ba188b76c0ed09fc5f4

--- a/Assets/Scripts/Space4x/Input/Space4XRtsInputBootstrap.cs
+++ b/Assets/Scripts/Space4x/Input/Space4XRtsInputBootstrap.cs
@@ -19,16 +19,32 @@ namespace Space4X.Input
             if (RuntimeMode.IsHeadless)
                 return;
 
-            if (FindFirstObjectByType<RtsInputBridge>() != null)
+            var existingBridge = FindFirstObjectByType<RtsInputBridge>();
+            if (existingBridge != null)
+            {
+                EnsureClassicCommandsBridge(existingBridge.gameObject);
                 return;
+            }
 
             var go = new GameObject("RTS Input Bridge");
             var bridge = go.AddComponent<RtsInputBridge>();
             UnityEngine.Camera mainCam = UnityEngine.Camera.main;
             bridge.RaycastCamera = mainCam;
             bridge.SelectionMask = ~0;
+            EnsureClassicCommandsBridge(go);
             go.AddComponent<Space4XRtsInputBootstrap>();
             DontDestroyOnLoad(go);
+        }
+
+        private static void EnsureClassicCommandsBridge(GameObject go)
+        {
+            if (go == null)
+                return;
+
+            if (go.GetComponent<Space4XRtsClassicCommandMono>() == null)
+            {
+                go.AddComponent<Space4XRtsClassicCommandMono>();
+            }
         }
     }
 }

--- a/Assets/Scripts/Space4x/Input/Space4XRtsInputBootstrap.cs
+++ b/Assets/Scripts/Space4x/Input/Space4XRtsInputBootstrap.cs
@@ -45,6 +45,11 @@ namespace Space4X.Input
             {
                 go.AddComponent<Space4XRtsClassicCommandMono>();
             }
+
+            if (go.GetComponent<Space4XRtsInputModeGateMono>() == null)
+            {
+                go.AddComponent<Space4XRtsInputModeGateMono>();
+            }
         }
     }
 }

--- a/Assets/Scripts/Space4x/Input/Space4XRtsInputModeGateMono.cs
+++ b/Assets/Scripts/Space4x/Input/Space4XRtsInputModeGateMono.cs
@@ -1,0 +1,68 @@
+using PureDOTS.Input;
+using Space4X.UI;
+using UnityEngine;
+
+namespace Space4X.Input
+{
+    /// <summary>
+    /// Enables RTS input bridge only while RTS control mode is active.
+    /// Keeps mode 4 (Divine Hand) isolated from RTS selection/order input paths.
+    /// </summary>
+    [DefaultExecutionOrder(-890)]
+    [DisallowMultipleComponent]
+    public sealed class Space4XRtsInputModeGateMono : MonoBehaviour
+    {
+        [SerializeField] private bool keepEnabledOutsideRts;
+
+        private RtsInputBridge _bridge;
+        private Space4XRtsClassicCommandMono _classicCommands;
+
+        private void OnEnable()
+        {
+            ResolveReferences();
+            Space4XControlModeState.ModeChanged += OnModeChanged;
+            ApplyMode(Space4XControlModeState.CurrentMode);
+        }
+
+        private void OnDisable()
+        {
+            Space4XControlModeState.ModeChanged -= OnModeChanged;
+        }
+
+        private void OnModeChanged(Space4XControlMode mode)
+        {
+            ApplyMode(mode);
+        }
+
+        private void ResolveReferences()
+        {
+            if (_bridge == null)
+            {
+                _bridge = GetComponent<RtsInputBridge>();
+            }
+
+            if (_classicCommands == null)
+            {
+                _classicCommands = GetComponent<Space4XRtsClassicCommandMono>();
+            }
+        }
+
+        private void ApplyMode(Space4XControlMode mode)
+        {
+            ResolveReferences();
+
+            bool rtsEnabled = mode == Space4XControlMode.Rts;
+            bool bridgeEnabled = keepEnabledOutsideRts || rtsEnabled;
+
+            if (_bridge != null)
+            {
+                _bridge.enabled = bridgeEnabled;
+            }
+
+            if (_classicCommands != null)
+            {
+                _classicCommands.enabled = rtsEnabled;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Input/Space4XRtsInputModeGateMono.cs.meta
+++ b/Assets/Scripts/Space4x/Input/Space4XRtsInputModeGateMono.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5dcb942e9434fd0852354b0ecd5278b

--- a/Assets/Scripts/Space4x/Progression.meta
+++ b/Assets/Scripts/Space4x/Progression.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e93c8ec1728f4ca183e7c3f2ff1697cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
+++ b/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
@@ -1,0 +1,370 @@
+using System;
+using System.IO;
+using PureDOTS.Runtime.Components;
+using Space4X.Registry;
+using Space4x.Scenario;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Space4X.Progression
+{
+    public struct Space4XPersistentProgressionState : IComponentData
+    {
+        public int SchemaVersion;
+        public float TotalThrustGenerated;
+        public uint TotalMissilesFired;
+        public uint TotalKineticAmmoSpent;
+        public uint Revision;
+        public byte Dirty;
+        public double LastSavedWorldSeconds;
+    }
+
+    [InternalBufferCapacity(8)]
+    public struct Space4XPersistentWeaponMountTracker : IBufferElementData
+    {
+        public uint LastShotsFired;
+    }
+
+    [UpdateInGroup(typeof(InitializationSystemGroup))]
+    public partial struct Space4XPersistentProgressionBootstrapSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            if (SystemAPI.TryGetSingletonEntity<Space4XPersistentProgressionState>(out _))
+            {
+                return;
+            }
+
+            var entity = state.EntityManager.CreateEntity(typeof(Space4XPersistentProgressionState));
+            var loaded = Space4XPersistentProgressionStorage.LoadOrDefault();
+            state.EntityManager.SetComponentData(entity, loaded);
+        }
+    }
+
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(Space4X.Systems.AI.VesselMovementSystem))]
+    public partial struct Space4XPersistentThrustProgressionTrackingSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Space4XPersistentProgressionState>();
+            state.RequireForUpdate<TimeState>();
+            state.RequireForUpdate<RewindState>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var time = SystemAPI.GetSingleton<TimeState>();
+            var rewind = SystemAPI.GetSingleton<RewindState>();
+            if (time.IsPaused || rewind.Mode != RewindMode.Record)
+            {
+                return;
+            }
+
+            var em = state.EntityManager;
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            foreach (var (movement, entity) in SystemAPI.Query<RefRO<VesselMovement>>()
+                         .WithAll<PlayerFlagshipTag>()
+                         .WithNone<Space4XThrustProgressionTracker>()
+                         .WithEntityAccess())
+            {
+                ecb.AddComponent(entity, new Space4XThrustProgressionTracker
+                {
+                    LastSpeed = math.max(0f, movement.ValueRO.CurrentSpeed),
+                    Initialized = 1
+                });
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+
+            if (!SystemAPI.TryGetSingletonRW<Space4XPersistentProgressionState>(out var progression))
+            {
+                return;
+            }
+
+            var progressionState = progression.ValueRO;
+            foreach (var (movement, tracker) in SystemAPI.Query<RefRO<VesselMovement>, RefRW<Space4XThrustProgressionTracker>>()
+                         .WithAll<PlayerFlagshipTag>())
+            {
+                var speed = math.max(0f, movement.ValueRO.CurrentSpeed);
+                var previous = math.max(0f, tracker.ValueRO.LastSpeed);
+                var delta = speed - previous;
+                if (delta > 1e-5f)
+                {
+                    progressionState.TotalThrustGenerated += delta;
+                    progressionState.Revision += 1;
+                    progressionState.Dirty = 1;
+                }
+
+                tracker.ValueRW.LastSpeed = speed;
+                tracker.ValueRW.Initialized = 1;
+            }
+
+            progression.ValueRW = progressionState;
+        }
+    }
+
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(Space4X.Registry.Space4XWeaponSystem))]
+    public partial struct Space4XPersistentWeaponProgressionTrackingSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Space4XPersistentProgressionState>();
+            state.RequireForUpdate<TimeState>();
+            state.RequireForUpdate<RewindState>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var time = SystemAPI.GetSingleton<TimeState>();
+            var rewind = SystemAPI.GetSingleton<RewindState>();
+            if (time.IsPaused || rewind.Mode != RewindMode.Record)
+            {
+                return;
+            }
+
+            if (!SystemAPI.TryGetSingletonRW<Space4XPersistentProgressionState>(out var progression))
+            {
+                return;
+            }
+
+            var progressionState = progression.ValueRO;
+            var em = state.EntityManager;
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            foreach (var (_, entity) in SystemAPI.Query<DynamicBuffer<WeaponMount>>()
+                         .WithAll<PlayerFlagshipTag>()
+                         .WithNone<Space4XPersistentWeaponMountTracker>()
+                         .WithEntityAccess())
+            {
+                ecb.AddBuffer<Space4XPersistentWeaponMountTracker>(entity);
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+
+            foreach (var (mounts, entity) in SystemAPI.Query<DynamicBuffer<WeaponMount>>().WithAll<PlayerFlagshipTag>().WithEntityAccess())
+            {
+                var trackers = em.GetBuffer<Space4XPersistentWeaponMountTracker>(entity);
+
+                while (trackers.Length < mounts.Length)
+                {
+                    trackers.Add(new Space4XPersistentWeaponMountTracker());
+                }
+
+                if (trackers.Length > mounts.Length)
+                {
+                    trackers.ResizeUninitialized(mounts.Length);
+                }
+
+                for (var i = 0; i < mounts.Length; i++)
+                {
+                    var mount = mounts[i];
+                    var tracker = trackers[i];
+                    var currentShots = mount.ShotsFired;
+                    var previousShots = tracker.LastShotsFired;
+                    var deltaShots = currentShots >= previousShots ? currentShots - previousShots : currentShots;
+                    if (deltaShots > 0)
+                    {
+                        if (mount.Weapon.Type == WeaponType.Missile)
+                        {
+                            progressionState.TotalMissilesFired += deltaShots;
+                        }
+
+                        if (mount.Weapon.Type == WeaponType.Kinetic)
+                        {
+                            var ammoPerShot = math.max(1, (int)mount.Weapon.AmmoPerShot);
+                            progressionState.TotalKineticAmmoSpent += (uint)(deltaShots * (uint)ammoPerShot);
+                        }
+
+                        progressionState.Revision += deltaShots;
+                        progressionState.Dirty = 1;
+                    }
+
+                    tracker.LastShotsFired = currentShots;
+                    trackers[i] = tracker;
+                }
+            }
+
+            progression.ValueRW = progressionState;
+        }
+    }
+
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(Space4XPersistentWeaponProgressionTrackingSystem))]
+    public partial struct Space4XPersistentProgressionFlushSystem : ISystem
+    {
+        private const float SaveIntervalSeconds = 2f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Space4XPersistentProgressionState>();
+            state.RequireForUpdate<TimeState>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            if (!SystemAPI.TryGetSingletonRW<Space4XPersistentProgressionState>(out var progression))
+            {
+                return;
+            }
+
+            var data = progression.ValueRO;
+            if (data.Dirty == 0)
+            {
+                return;
+            }
+
+            var worldSeconds = SystemAPI.GetSingleton<TimeState>().WorldSeconds;
+            if (worldSeconds - data.LastSavedWorldSeconds < SaveIntervalSeconds)
+            {
+                return;
+            }
+
+            if (!Space4XPersistentProgressionStorage.TrySave(in data))
+            {
+                return;
+            }
+
+            data.Dirty = 0;
+            data.LastSavedWorldSeconds = worldSeconds;
+            progression.ValueRW = data;
+        }
+
+        public void OnDestroy(ref SystemState state)
+        {
+            var query = state.GetEntityQuery(ComponentType.ReadOnly<Space4XPersistentProgressionState>());
+            if (query.IsEmptyIgnoreFilter)
+            {
+                return;
+            }
+
+            var entity = query.GetSingletonEntity();
+            var data = state.EntityManager.GetComponentData<Space4XPersistentProgressionState>(entity);
+            if (data.Dirty != 0)
+            {
+                Space4XPersistentProgressionStorage.TrySave(in data);
+            }
+        }
+    }
+
+    public struct Space4XThrustProgressionTracker : IComponentData
+    {
+        public float LastSpeed;
+        public byte Initialized;
+    }
+
+    internal static class Space4XPersistentProgressionStorage
+    {
+        private const int CurrentSchemaVersion = 1;
+        private const string FileName = "space4x_fleetcrawl_progression_v1.json";
+
+        public static Space4XPersistentProgressionState LoadOrDefault()
+        {
+            var state = new Space4XPersistentProgressionState
+            {
+                SchemaVersion = CurrentSchemaVersion,
+                TotalThrustGenerated = 0f,
+                TotalMissilesFired = 0,
+                TotalKineticAmmoSpent = 0,
+                Revision = 0,
+                Dirty = 0,
+                LastSavedWorldSeconds = 0d
+            };
+
+            try
+            {
+                var path = ResolvePath();
+                if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                {
+                    return state;
+                }
+
+                var json = File.ReadAllText(path);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    return state;
+                }
+
+                var payload = JsonUtility.FromJson<Space4XPersistentProgressionFileData>(json);
+                if (payload == null || payload.schemaVersion <= 0)
+                {
+                    return state;
+                }
+
+                state.SchemaVersion = payload.schemaVersion;
+                state.TotalThrustGenerated = math.max(0f, payload.totalThrustGenerated);
+                state.TotalMissilesFired = (uint)math.max(0, payload.totalMissilesFired);
+                state.TotalKineticAmmoSpent = (uint)math.max(0, payload.totalKineticAmmoSpent);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[Space4XPersistentProgression] Failed to load progression file: {ex.Message}");
+            }
+
+            return state;
+        }
+
+        public static bool TrySave(in Space4XPersistentProgressionState state)
+        {
+            try
+            {
+                var path = ResolvePath();
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    return false;
+                }
+
+                var dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrWhiteSpace(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                var payload = new Space4XPersistentProgressionFileData
+                {
+                    schemaVersion = CurrentSchemaVersion,
+                    totalThrustGenerated = math.max(0f, state.TotalThrustGenerated),
+                    totalMissilesFired = (int)math.max(0u, state.TotalMissilesFired),
+                    totalKineticAmmoSpent = (int)math.max(0u, state.TotalKineticAmmoSpent)
+                };
+
+                var json = JsonUtility.ToJson(payload, false);
+                File.WriteAllText(path, json);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[Space4XPersistentProgression] Failed to save progression file: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static string ResolvePath()
+        {
+            var root = Application.persistentDataPath;
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                return string.Empty;
+            }
+
+            return Path.Combine(root, FileName);
+        }
+
+        [Serializable]
+        private sealed class Space4XPersistentProgressionFileData
+        {
+            public int schemaVersion;
+            public float totalThrustGenerated;
+            public int totalMissilesFired;
+            public int totalKineticAmmoSpent;
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs.meta
+++ b/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2a636379dbc41e592a069e26d7a0fef

--- a/Assets/Scripts/Space4x/Registry/Space4XFocusAbilityDefinitions.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XFocusAbilityDefinitions.cs
@@ -419,6 +419,16 @@ namespace Space4X.Registry
         }
 
         /// <summary>
+        /// Gets special-energy activation cost for this ability.
+        /// </summary>
+        public static float GetSpecialEnergyActivationCost(Space4XFocusAbilityType ability)
+        {
+            var drainRate = GetDrainRate(ability);
+            // Keep costs in a practical range while scaling with ability intensity.
+            return math.clamp(drainRate * 28f, 2f, 16f);
+        }
+
+        /// <summary>
         /// Gets whether ability requires a target.
         /// </summary>
         public static bool RequiresTarget(Space4XFocusAbilityType ability)
@@ -617,4 +627,3 @@ namespace Space4X.Registry
         }
     }
 }
-

--- a/Assets/Scripts/Space4x/Registry/Space4XSpecialEnergyTelemetrySystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XSpecialEnergyTelemetrySystem.cs
@@ -1,0 +1,70 @@
+using PureDOTS.Runtime.Telemetry;
+using Space4X.Runtime;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Space4X.Registry
+{
+    [BurstCompile]
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct Space4XSpecialEnergyTelemetrySystem : ISystem
+    {
+        [BurstCompile]
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<TelemetryStream>();
+            state.RequireForUpdate<TelemetryExportConfig>();
+            state.RequireForUpdate<ShipSpecialEnergyState>();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            if (!SystemAPI.TryGetSingleton<TelemetryExportConfig>(out var config) ||
+                (config.Flags & TelemetryExportFlags.IncludeTelemetryMetrics) == 0)
+            {
+                return;
+            }
+
+            if (!SystemAPI.TryGetSingletonEntity<TelemetryStream>(out var telemetryEntity) ||
+                !state.EntityManager.HasBuffer<TelemetryMetric>(telemetryEntity))
+            {
+                return;
+            }
+
+            var shipCount = 0;
+            var ratioSum = 0f;
+            var ratioMin = 1f;
+            var ratioMax = 0f;
+            var spentTickTotal = 0f;
+            var failedSpendTotal = 0f;
+
+            foreach (var energy in SystemAPI.Query<RefRO<ShipSpecialEnergyState>>())
+            {
+                shipCount++;
+                var ratio = math.saturate(energy.ValueRO.Ratio);
+                ratioSum += ratio;
+                ratioMin = math.min(ratioMin, ratio);
+                ratioMax = math.max(ratioMax, ratio);
+                spentTickTotal += math.max(0f, energy.ValueRO.LastSpent);
+                failedSpendTotal += energy.ValueRO.FailedSpendAttempts;
+            }
+
+            if (shipCount == 0)
+            {
+                return;
+            }
+
+            var avgRatio = ratioSum / shipCount;
+            var metrics = state.EntityManager.GetBuffer<TelemetryMetric>(telemetryEntity);
+            metrics.AddMetric(new FixedString64Bytes("space4x.special_energy.ship.samples"), shipCount, TelemetryMetricUnit.Count);
+            metrics.AddMetric(new FixedString64Bytes("space4x.special_energy.ship.avg_ratio"), avgRatio, TelemetryMetricUnit.Ratio);
+            metrics.AddMetric(new FixedString64Bytes("space4x.special_energy.ship.min_ratio"), ratioMin, TelemetryMetricUnit.Ratio);
+            metrics.AddMetric(new FixedString64Bytes("space4x.special_energy.ship.max_ratio"), ratioMax, TelemetryMetricUnit.Ratio);
+            metrics.AddMetric(new FixedString64Bytes("space4x.special_energy.spend.tick_total"), spentTickTotal, TelemetryMetricUnit.Custom);
+            metrics.AddMetric(new FixedString64Bytes("space4x.special_energy.spend.failed_total"), failedSpendTotal, TelemetryMetricUnit.Count);
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Registry/Space4XSpecialEnergyTelemetrySystem.cs.meta
+++ b/Assets/Scripts/Space4x/Registry/Space4XSpecialEnergyTelemetrySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5643358c791f426ab85a6073978c9279

--- a/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs
@@ -1,0 +1,175 @@
+using Unity.Mathematics;
+
+namespace Space4X.Registry
+{
+    public enum Space4XWeaponNuanceArchetype : byte
+    {
+        Default = 0,
+        Energy = 1,
+        Kinetic = 2,
+        GuidedMissile = 3,
+        GuidedHeavy = 4,
+        DissipativePlasma = 5,
+        DissipativeFlame = 6
+    }
+
+    public readonly struct Space4XWeaponFamilyNuanceProfile
+    {
+        public readonly float HeatMultiplier;
+        public readonly float AmmoMultiplier;
+        public readonly float HitChanceMultiplier;
+        public readonly float DamageNearMultiplier;
+        public readonly float DamageFarMultiplier;
+        public readonly float DamageFalloffStart01;
+        public readonly float DamageFalloffEnd01;
+
+        public Space4XWeaponFamilyNuanceProfile(
+            float heatMultiplier,
+            float ammoMultiplier,
+            float hitChanceMultiplier,
+            float damageNearMultiplier,
+            float damageFarMultiplier,
+            float damageFalloffStart01,
+            float damageFalloffEnd01)
+        {
+            HeatMultiplier = heatMultiplier;
+            AmmoMultiplier = ammoMultiplier;
+            HitChanceMultiplier = hitChanceMultiplier;
+            DamageNearMultiplier = damageNearMultiplier;
+            DamageFarMultiplier = damageFarMultiplier;
+            DamageFalloffStart01 = damageFalloffStart01;
+            DamageFalloffEnd01 = damageFalloffEnd01;
+        }
+    }
+
+    public static class Space4XWeaponFamilyNuance
+    {
+        public static Space4XWeaponNuanceArchetype ResolveArchetype(in Space4XWeapon weapon)
+        {
+            return weapon.Type switch
+            {
+                WeaponType.Plasma => Space4XWeaponNuanceArchetype.DissipativePlasma,
+                WeaponType.Missile => Space4XWeaponNuanceArchetype.GuidedMissile,
+                WeaponType.Torpedo => Space4XWeaponNuanceArchetype.GuidedHeavy,
+                WeaponType.Laser or WeaponType.Ion => Space4XWeaponNuanceArchetype.Energy,
+                WeaponType.Kinetic or WeaponType.PointDefense or WeaponType.Flak => Space4XWeaponNuanceArchetype.Kinetic,
+                _ => Space4XWeaponNuanceArchetype.Default
+            };
+        }
+
+        public static Space4XWeaponFamilyNuanceProfile ResolveProfile(Space4XWeaponNuanceArchetype archetype)
+        {
+            return archetype switch
+            {
+                Space4XWeaponNuanceArchetype.Energy => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 1.2f,
+                    ammoMultiplier: 0f,
+                    hitChanceMultiplier: 1f,
+                    damageNearMultiplier: 1.02f,
+                    damageFarMultiplier: 0.95f,
+                    damageFalloffStart01: 0.4f,
+                    damageFalloffEnd01: 1f),
+                Space4XWeaponNuanceArchetype.Kinetic => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 0.8f,
+                    ammoMultiplier: 1f,
+                    hitChanceMultiplier: 1f,
+                    damageNearMultiplier: 1f,
+                    damageFarMultiplier: 0.9f,
+                    damageFalloffStart01: 0.5f,
+                    damageFalloffEnd01: 1f),
+                Space4XWeaponNuanceArchetype.GuidedMissile => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 0.95f,
+                    ammoMultiplier: 1.8f,
+                    hitChanceMultiplier: 0.82f,
+                    damageNearMultiplier: 1f,
+                    damageFarMultiplier: 1f,
+                    damageFalloffStart01: 1f,
+                    damageFalloffEnd01: 1f),
+                Space4XWeaponNuanceArchetype.GuidedHeavy => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 1.05f,
+                    ammoMultiplier: 2.3f,
+                    hitChanceMultiplier: 0.74f,
+                    damageNearMultiplier: 1.08f,
+                    damageFarMultiplier: 0.96f,
+                    damageFalloffStart01: 0.7f,
+                    damageFalloffEnd01: 1f),
+                Space4XWeaponNuanceArchetype.DissipativePlasma => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 1.35f,
+                    ammoMultiplier: 0f,
+                    hitChanceMultiplier: 1f,
+                    damageNearMultiplier: 1.08f,
+                    damageFarMultiplier: 0.42f,
+                    damageFalloffStart01: 0.35f,
+                    damageFalloffEnd01: 1f),
+                Space4XWeaponNuanceArchetype.DissipativeFlame => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 1.25f,
+                    ammoMultiplier: 0f,
+                    hitChanceMultiplier: 1f,
+                    damageNearMultiplier: 1.15f,
+                    damageFarMultiplier: 0.25f,
+                    damageFalloffStart01: 0.2f,
+                    damageFalloffEnd01: 0.8f),
+                _ => new Space4XWeaponFamilyNuanceProfile(
+                    heatMultiplier: 1f,
+                    ammoMultiplier: 1f,
+                    hitChanceMultiplier: 1f,
+                    damageNearMultiplier: 1f,
+                    damageFarMultiplier: 1f,
+                    damageFalloffStart01: 1f,
+                    damageFalloffEnd01: 1f)
+            };
+        }
+
+        public static float ResolveHeatPerShot(float baseHeatPerShot, in Space4XWeaponFamilyNuanceProfile profile)
+        {
+            return math.max(0f, baseHeatPerShot * math.max(0f, profile.HeatMultiplier));
+        }
+
+        public static int ResolveAmmoPerShot(int baseAmmoPerShot, in Space4XWeaponFamilyNuanceProfile profile)
+        {
+            if (baseAmmoPerShot <= 0)
+            {
+                return 0;
+            }
+
+            if (profile.AmmoMultiplier <= 0f)
+            {
+                return 0;
+            }
+
+            return math.max(1, (int)math.ceil(baseAmmoPerShot * profile.AmmoMultiplier));
+        }
+
+        public static float ResolveHitChanceMultiplier(in Space4XWeaponFamilyNuanceProfile profile)
+        {
+            return math.clamp(profile.HitChanceMultiplier, 0.05f, 1.5f);
+        }
+
+        public static float ResolveDistanceDamageMultiplier(
+            float distance,
+            float optimalRange,
+            float maxRange,
+            in Space4XWeaponFamilyNuanceProfile profile)
+        {
+            if (distance <= 0f)
+            {
+                return math.max(0f, profile.DamageNearMultiplier);
+            }
+
+            var effectiveMax = math.max(1f, maxRange);
+            var normalized = math.saturate(distance / effectiveMax);
+
+            var start = math.clamp(profile.DamageFalloffStart01, 0f, 1f);
+            var end = math.clamp(math.max(start + 0.0001f, profile.DamageFalloffEnd01), 0.0001f, 1f);
+
+            if (optimalRange > 0f && effectiveMax > 0f)
+            {
+                var optimal01 = math.saturate(optimalRange / effectiveMax);
+                start = math.max(start, optimal01 * 0.75f);
+            }
+
+            var t = math.saturate((normalized - start) / math.max(0.0001f, end - start));
+            return math.lerp(profile.DamageNearMultiplier, profile.DamageFarMultiplier, t);
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs
@@ -23,6 +23,7 @@ namespace Space4X.Registry
         public readonly float DamageFalloffStart01;
         public readonly float DamageFalloffEnd01;
         public readonly float HeatSeekSignatureGain;
+        public readonly float HazardOcclusionResistance;
 
         public Space4XWeaponFamilyNuanceProfile(
             float heatMultiplier,
@@ -32,7 +33,8 @@ namespace Space4X.Registry
             float damageFarMultiplier,
             float damageFalloffStart01,
             float damageFalloffEnd01,
-            float heatSeekSignatureGain)
+            float heatSeekSignatureGain,
+            float hazardOcclusionResistance)
         {
             HeatMultiplier = heatMultiplier;
             AmmoMultiplier = ammoMultiplier;
@@ -42,6 +44,7 @@ namespace Space4X.Registry
             DamageFalloffStart01 = damageFalloffStart01;
             DamageFalloffEnd01 = damageFalloffEnd01;
             HeatSeekSignatureGain = heatSeekSignatureGain;
+            HazardOcclusionResistance = hazardOcclusionResistance;
         }
     }
 
@@ -72,7 +75,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 0.95f,
                     damageFalloffStart01: 0.4f,
                     damageFalloffEnd01: 1f,
-                    heatSeekSignatureGain: 0f),
+                    heatSeekSignatureGain: 0f,
+                    hazardOcclusionResistance: 0.92f),
                 Space4XWeaponNuanceArchetype.Kinetic => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 0.8f,
                     ammoMultiplier: 1f,
@@ -81,7 +85,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 0.9f,
                     damageFalloffStart01: 0.5f,
                     damageFalloffEnd01: 1f,
-                    heatSeekSignatureGain: 0f),
+                    heatSeekSignatureGain: 0f,
+                    hazardOcclusionResistance: 0.18f),
                 Space4XWeaponNuanceArchetype.GuidedMissile => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 0.95f,
                     ammoMultiplier: 1.8f,
@@ -90,7 +95,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 1f,
                     damageFalloffStart01: 1f,
                     damageFalloffEnd01: 1f,
-                    heatSeekSignatureGain: 0.28f),
+                    heatSeekSignatureGain: 0.28f,
+                    hazardOcclusionResistance: 0.46f),
                 Space4XWeaponNuanceArchetype.GuidedHeavy => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1.05f,
                     ammoMultiplier: 2.3f,
@@ -99,7 +105,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 0.96f,
                     damageFalloffStart01: 0.7f,
                     damageFalloffEnd01: 1f,
-                    heatSeekSignatureGain: 0.4f),
+                    heatSeekSignatureGain: 0.4f,
+                    hazardOcclusionResistance: 0.62f),
                 Space4XWeaponNuanceArchetype.DissipativePlasma => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1.35f,
                     ammoMultiplier: 0f,
@@ -108,7 +115,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 0.42f,
                     damageFalloffStart01: 0.35f,
                     damageFalloffEnd01: 1f,
-                    heatSeekSignatureGain: 0f),
+                    heatSeekSignatureGain: 0f,
+                    hazardOcclusionResistance: 0.85f),
                 Space4XWeaponNuanceArchetype.DissipativeFlame => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1.25f,
                     ammoMultiplier: 0f,
@@ -117,7 +125,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 0.25f,
                     damageFalloffStart01: 0.2f,
                     damageFalloffEnd01: 0.8f,
-                    heatSeekSignatureGain: 0f),
+                    heatSeekSignatureGain: 0f,
+                    hazardOcclusionResistance: 0.88f),
                 _ => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1f,
                     ammoMultiplier: 1f,
@@ -126,7 +135,8 @@ namespace Space4X.Registry
                     damageFarMultiplier: 1f,
                     damageFalloffStart01: 1f,
                     damageFalloffEnd01: 1f,
-                    heatSeekSignatureGain: 0f)
+                    heatSeekSignatureGain: 0f,
+                    hazardOcclusionResistance: 0.3f)
             };
         }
 
@@ -160,6 +170,19 @@ namespace Space4X.Registry
             var heat01 = math.saturate(targetHeatSignature01);
             var gain = math.max(0f, profile.HeatSeekSignatureGain);
             return math.clamp(1f + gain * heat01, 1f, 1.6f);
+        }
+
+        public static float ResolveHazardOcclusionHitChanceMultiplier(
+            float laneOcclusion01,
+            float projectedBlastRadius,
+            in Space4XWeaponFamilyNuanceProfile profile)
+        {
+            var occlusion = math.saturate(laneOcclusion01);
+            var blastAssist = math.saturate(math.max(0f, projectedBlastRadius) / 16f);
+            var effectiveOcclusion = occlusion * (1f - blastAssist * 0.6f);
+            var resistance = math.saturate(profile.HazardOcclusionResistance);
+            var minMultiplier = math.lerp(0.45f, 1f, resistance);
+            return math.lerp(1f, minMultiplier, effectiveOcclusion);
         }
 
         public static float ResolveDistanceDamageMultiplier(

--- a/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs
@@ -22,6 +22,7 @@ namespace Space4X.Registry
         public readonly float DamageFarMultiplier;
         public readonly float DamageFalloffStart01;
         public readonly float DamageFalloffEnd01;
+        public readonly float HeatSeekSignatureGain;
 
         public Space4XWeaponFamilyNuanceProfile(
             float heatMultiplier,
@@ -30,7 +31,8 @@ namespace Space4X.Registry
             float damageNearMultiplier,
             float damageFarMultiplier,
             float damageFalloffStart01,
-            float damageFalloffEnd01)
+            float damageFalloffEnd01,
+            float heatSeekSignatureGain)
         {
             HeatMultiplier = heatMultiplier;
             AmmoMultiplier = ammoMultiplier;
@@ -39,6 +41,7 @@ namespace Space4X.Registry
             DamageFarMultiplier = damageFarMultiplier;
             DamageFalloffStart01 = damageFalloffStart01;
             DamageFalloffEnd01 = damageFalloffEnd01;
+            HeatSeekSignatureGain = heatSeekSignatureGain;
         }
     }
 
@@ -68,7 +71,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1.02f,
                     damageFarMultiplier: 0.95f,
                     damageFalloffStart01: 0.4f,
-                    damageFalloffEnd01: 1f),
+                    damageFalloffEnd01: 1f,
+                    heatSeekSignatureGain: 0f),
                 Space4XWeaponNuanceArchetype.Kinetic => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 0.8f,
                     ammoMultiplier: 1f,
@@ -76,7 +80,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1f,
                     damageFarMultiplier: 0.9f,
                     damageFalloffStart01: 0.5f,
-                    damageFalloffEnd01: 1f),
+                    damageFalloffEnd01: 1f,
+                    heatSeekSignatureGain: 0f),
                 Space4XWeaponNuanceArchetype.GuidedMissile => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 0.95f,
                     ammoMultiplier: 1.8f,
@@ -84,7 +89,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1f,
                     damageFarMultiplier: 1f,
                     damageFalloffStart01: 1f,
-                    damageFalloffEnd01: 1f),
+                    damageFalloffEnd01: 1f,
+                    heatSeekSignatureGain: 0.28f),
                 Space4XWeaponNuanceArchetype.GuidedHeavy => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1.05f,
                     ammoMultiplier: 2.3f,
@@ -92,7 +98,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1.08f,
                     damageFarMultiplier: 0.96f,
                     damageFalloffStart01: 0.7f,
-                    damageFalloffEnd01: 1f),
+                    damageFalloffEnd01: 1f,
+                    heatSeekSignatureGain: 0.4f),
                 Space4XWeaponNuanceArchetype.DissipativePlasma => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1.35f,
                     ammoMultiplier: 0f,
@@ -100,7 +107,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1.08f,
                     damageFarMultiplier: 0.42f,
                     damageFalloffStart01: 0.35f,
-                    damageFalloffEnd01: 1f),
+                    damageFalloffEnd01: 1f,
+                    heatSeekSignatureGain: 0f),
                 Space4XWeaponNuanceArchetype.DissipativeFlame => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1.25f,
                     ammoMultiplier: 0f,
@@ -108,7 +116,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1.15f,
                     damageFarMultiplier: 0.25f,
                     damageFalloffStart01: 0.2f,
-                    damageFalloffEnd01: 0.8f),
+                    damageFalloffEnd01: 0.8f,
+                    heatSeekSignatureGain: 0f),
                 _ => new Space4XWeaponFamilyNuanceProfile(
                     heatMultiplier: 1f,
                     ammoMultiplier: 1f,
@@ -116,7 +125,8 @@ namespace Space4X.Registry
                     damageNearMultiplier: 1f,
                     damageFarMultiplier: 1f,
                     damageFalloffStart01: 1f,
-                    damageFalloffEnd01: 1f)
+                    damageFalloffEnd01: 1f,
+                    heatSeekSignatureGain: 0f)
             };
         }
 
@@ -143,6 +153,13 @@ namespace Space4X.Registry
         public static float ResolveHitChanceMultiplier(in Space4XWeaponFamilyNuanceProfile profile)
         {
             return math.clamp(profile.HitChanceMultiplier, 0.05f, 1.5f);
+        }
+
+        public static float ResolveHeatSeekHitChanceMultiplier(float targetHeatSignature01, in Space4XWeaponFamilyNuanceProfile profile)
+        {
+            var heat01 = math.saturate(targetHeatSignature01);
+            var gain = math.max(0f, profile.HeatSeekSignatureGain);
+            return math.clamp(1f + gain * heat01, 1f, 1.6f);
         }
 
         public static float ResolveDistanceDamageMultiplier(

--- a/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs.meta
+++ b/Assets/Scripts/Space4x/Registry/Space4XWeaponFamilyNuance.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7de84b12c0134df1a7a777ed4c6404ab

--- a/Assets/Scripts/Space4x/Runtime/Interaction/Space4XControlModeRuntimeState.cs
+++ b/Assets/Scripts/Space4x/Runtime/Interaction/Space4XControlModeRuntimeState.cs
@@ -1,0 +1,49 @@
+using Space4X.UI;
+using Unity.Entities;
+
+namespace Space4X.Runtime.Interaction
+{
+    /// <summary>
+    /// ECS-readable snapshot of presentation control mode state.
+    /// Lets Burst hand/order systems react to mode changes without managed dependencies.
+    /// </summary>
+    public struct Space4XControlModeRuntimeState : IComponentData
+    {
+        public byte Mode;
+        public byte UsesRtsRig;
+        public byte IsRtsOrdersEnabled;
+        public byte IsDivineHandEnabled;
+    }
+
+    [UpdateInGroup(typeof(InitializationSystemGroup))]
+    public partial struct Space4XControlModeRuntimeSyncSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            if (SystemAPI.TryGetSingletonEntity<Space4XControlModeRuntimeState>(out _))
+            {
+                return;
+            }
+
+            var entity = state.EntityManager.CreateEntity(typeof(Space4XControlModeRuntimeState));
+            state.EntityManager.SetComponentData(entity, BuildState(Space4XControlModeState.CurrentMode));
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            SystemAPI.SetSingleton(BuildState(Space4XControlModeState.CurrentMode));
+        }
+
+        private static Space4XControlModeRuntimeState BuildState(Space4XControlMode mode)
+        {
+            bool usesRtsRig = mode == Space4XControlMode.Rts || mode == Space4XControlMode.DivineHand;
+            return new Space4XControlModeRuntimeState
+            {
+                Mode = (byte)mode,
+                UsesRtsRig = (byte)(usesRtsRig ? 1 : 0),
+                IsRtsOrdersEnabled = (byte)(mode == Space4XControlMode.Rts ? 1 : 0),
+                IsDivineHandEnabled = (byte)(mode == Space4XControlMode.DivineHand ? 1 : 0)
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Runtime/Interaction/Space4XControlModeRuntimeState.cs.meta
+++ b/Assets/Scripts/Space4x/Runtime/Interaction/Space4XControlModeRuntimeState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cc3a198777334413b24d93c2a9412a0a

--- a/Assets/Scripts/Space4x/Runtime/Space4XSpecialEnergyComponents.cs
+++ b/Assets/Scripts/Space4x/Runtime/Space4XSpecialEnergyComponents.cs
@@ -1,57 +1,140 @@
 using Unity.Collections;
 using Unity.Entities;
+using PureDOTS.Runtime.Resources;
 
 namespace Space4X.Runtime
 {
     public struct ShipSpecialEnergyConfig : IComponentData
     {
-        public float BaseMax;
-        public float BaseRegenPerSecond;
+        public ResourcePoolConfig Pool;
         public float ReactorOutputToMax;
         public float ReactorOutputToRegen;
         public float ReactorEfficiencyRegenMultiplier;
         public float RestartRegenPenaltyMultiplier;
-        public float ActivationCostMultiplier;
+
+        public float BaseMax
+        {
+            get => Pool.BaseMax;
+            set => Pool.BaseMax = value;
+        }
+
+        public float BaseRegenPerSecond
+        {
+            get => Pool.BaseRegenPerSecond;
+            set => Pool.BaseRegenPerSecond = value;
+        }
+
+        public float ActivationCostMultiplier
+        {
+            get => Pool.SpendCostMultiplier;
+            set => Pool.SpendCostMultiplier = value;
+        }
 
         public static ShipSpecialEnergyConfig Default => new ShipSpecialEnergyConfig
         {
-            BaseMax = 40f,
-            BaseRegenPerSecond = 3f,
+            Pool = new ResourcePoolConfig
+            {
+                BaseMax = 40f,
+                BaseRegenPerSecond = 3f,
+                SpendCostMultiplier = 1f
+            },
             ReactorOutputToMax = 0.02f,
             ReactorOutputToRegen = 0.0015f,
             ReactorEfficiencyRegenMultiplier = 1f,
-            RestartRegenPenaltyMultiplier = 0.2f,
-            ActivationCostMultiplier = 1f
+            RestartRegenPenaltyMultiplier = 0.2f
         };
     }
 
     public struct ShipSpecialEnergyState : IComponentData
     {
-        public float Current;
-        public float EffectiveMax;
-        public float EffectiveRegenPerSecond;
-        public float LastSpent;
-        public uint LastSpendTick;
-        public ushort FailedSpendAttempts;
-        public uint LastUpdatedTick;
+        public ResourcePoolState Pool;
 
-        public float Ratio => EffectiveMax > 0f ? Current / EffectiveMax : 0f;
+        public float Current
+        {
+            get => Pool.Current;
+            set => Pool.Current = value;
+        }
+
+        public float EffectiveMax
+        {
+            get => Pool.EffectiveMax;
+            set => Pool.EffectiveMax = value;
+        }
+
+        public float EffectiveRegenPerSecond
+        {
+            get => Pool.EffectiveRegenPerSecond;
+            set => Pool.EffectiveRegenPerSecond = value;
+        }
+
+        public float LastSpent
+        {
+            get => Pool.LastSpent;
+            set => Pool.LastSpent = value;
+        }
+
+        public uint LastSpendTick
+        {
+            get => Pool.LastSpendTick;
+            set => Pool.LastSpendTick = value;
+        }
+
+        public ushort FailedSpendAttempts
+        {
+            get => Pool.FailedSpendAttempts;
+            set => Pool.FailedSpendAttempts = value;
+        }
+
+        public uint LastUpdatedTick
+        {
+            get => Pool.LastUpdatedTick;
+            set => Pool.LastUpdatedTick = value;
+        }
+
+        public float Ratio => Pool.Ratio;
     }
 
     [InternalBufferCapacity(4)]
     public struct ShipSpecialEnergyPassiveModifier : IBufferElementData
     {
         public FixedString64Bytes SourceId;
-        public float AdditiveMax;
-        public float MultiplicativeMax;
-        public float AdditiveRegenPerSecond;
-        public float MultiplicativeRegen;
+        public ResourcePoolModifier PoolModifier;
+
+        public float AdditiveMax
+        {
+            get => PoolModifier.AdditiveMax;
+            set => PoolModifier.AdditiveMax = value;
+        }
+
+        public float MultiplicativeMax
+        {
+            get => PoolModifier.MultiplicativeMax;
+            set => PoolModifier.MultiplicativeMax = value;
+        }
+
+        public float AdditiveRegenPerSecond
+        {
+            get => PoolModifier.AdditiveRegenPerSecond;
+            set => PoolModifier.AdditiveRegenPerSecond = value;
+        }
+
+        public float MultiplicativeRegen
+        {
+            get => PoolModifier.MultiplicativeRegen;
+            set => PoolModifier.MultiplicativeRegen = value;
+        }
     }
 
     [InternalBufferCapacity(4)]
     public struct ShipSpecialEnergySpendRequest : IBufferElementData
     {
         public FixedString64Bytes Reason;
-        public float Amount;
+        public ResourcePoolSpendRequest Request;
+
+        public float Amount
+        {
+            get => Request.Amount;
+            set => Request.Amount = value;
+        }
     }
 }

--- a/Assets/Scripts/Space4x/Runtime/Space4XSpecialEnergyComponents.cs
+++ b/Assets/Scripts/Space4x/Runtime/Space4XSpecialEnergyComponents.cs
@@ -1,0 +1,57 @@
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Space4X.Runtime
+{
+    public struct ShipSpecialEnergyConfig : IComponentData
+    {
+        public float BaseMax;
+        public float BaseRegenPerSecond;
+        public float ReactorOutputToMax;
+        public float ReactorOutputToRegen;
+        public float ReactorEfficiencyRegenMultiplier;
+        public float RestartRegenPenaltyMultiplier;
+        public float ActivationCostMultiplier;
+
+        public static ShipSpecialEnergyConfig Default => new ShipSpecialEnergyConfig
+        {
+            BaseMax = 40f,
+            BaseRegenPerSecond = 3f,
+            ReactorOutputToMax = 0.02f,
+            ReactorOutputToRegen = 0.0015f,
+            ReactorEfficiencyRegenMultiplier = 1f,
+            RestartRegenPenaltyMultiplier = 0.2f,
+            ActivationCostMultiplier = 1f
+        };
+    }
+
+    public struct ShipSpecialEnergyState : IComponentData
+    {
+        public float Current;
+        public float EffectiveMax;
+        public float EffectiveRegenPerSecond;
+        public float LastSpent;
+        public uint LastSpendTick;
+        public ushort FailedSpendAttempts;
+        public uint LastUpdatedTick;
+
+        public float Ratio => EffectiveMax > 0f ? Current / EffectiveMax : 0f;
+    }
+
+    [InternalBufferCapacity(4)]
+    public struct ShipSpecialEnergyPassiveModifier : IBufferElementData
+    {
+        public FixedString64Bytes SourceId;
+        public float AdditiveMax;
+        public float MultiplicativeMax;
+        public float AdditiveRegenPerSecond;
+        public float MultiplicativeRegen;
+    }
+
+    [InternalBufferCapacity(4)]
+    public struct ShipSpecialEnergySpendRequest : IBufferElementData
+    {
+        public FixedString64Bytes Reason;
+        public float Amount;
+    }
+}

--- a/Assets/Scripts/Space4x/Runtime/Space4XSpecialEnergyComponents.cs.meta
+++ b/Assets/Scripts/Space4x/Runtime/Space4XSpecialEnergyComponents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d05e536f1e404c919fc3ea173c69197c

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlMetaProficiencySystems.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlMetaProficiencySystems.cs
@@ -1,0 +1,368 @@
+using System;
+using PureDOTS.Runtime.Components;
+using PureDOTS.Runtime.Progression;
+using Space4X.Registry;
+using Space4X.Runtime;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Space4x.Scenario
+{
+    [Flags]
+    public enum Space4XRunMetaUnlockFlags : ushort
+    {
+        None = 0,
+        DamageTypeSpecialist = 1 << 0,
+        MitigationSpecialist = 1 << 1,
+        CloakOperator = 1 << 2,
+        ChronoOperator = 1 << 3,
+        OrdnanceSpecialist = 1 << 4,
+        InterceptorSpecialist = 1 << 5,
+        CapitalHunter = 1 << 6,
+        CacheHunter = 1 << 7
+    }
+
+    public struct Space4XRunMetaProficiencyState : IComponentData
+    {
+        public float DamageDealtEnergy;
+        public float DamageDealtThermal;
+        public float DamageDealtEM;
+        public float DamageDealtRadiation;
+        public float DamageDealtCaustic;
+        public float DamageDealtKinetic;
+        public float DamageDealtExplosive;
+
+        public float DamageMitigatedEnergy;
+        public float DamageMitigatedThermal;
+        public float DamageMitigatedEM;
+        public float DamageMitigatedRadiation;
+        public float DamageMitigatedCaustic;
+        public float DamageMitigatedKinetic;
+        public float DamageMitigatedExplosive;
+
+        public float CloakSeconds;
+        public float TimeStopRequestedSeconds;
+        public float MissileDamageDealt;
+
+        public int CraftShotDown;
+        public int CapitalShipsDestroyed;
+        public int HiddenCachesFound;
+    }
+
+    public struct Space4XRunMetaProficiencyConfig : IComponentData
+    {
+        public float DamageThreshold;
+        public float MitigationThreshold;
+        public float CloakSecondsThreshold;
+        public float TimeStopSecondsThreshold;
+        public float MissileDamageThreshold;
+        public int CraftShotDownThreshold;
+        public int CapitalShipsDestroyedThreshold;
+        public int HiddenCachesFoundThreshold;
+
+        public static Space4XRunMetaProficiencyConfig Default => new Space4XRunMetaProficiencyConfig
+        {
+            DamageThreshold = 1600f,
+            MitigationThreshold = 900f,
+            CloakSecondsThreshold = 18f,
+            TimeStopSecondsThreshold = 12f,
+            MissileDamageThreshold = 450f,
+            CraftShotDownThreshold = 18,
+            CapitalShipsDestroyedThreshold = 2,
+            HiddenCachesFoundThreshold = 3
+        };
+    }
+
+    public struct Space4XRunMetaUnlockState : IComponentData
+    {
+        public Space4XRunMetaUnlockFlags Flags;
+        public byte UnlockCount;
+    }
+
+    public struct Space4XRunMetaDamageEventCursor : IComponentData
+    {
+        public int ProcessedCount;
+    }
+
+    [InternalBufferCapacity(8)]
+    public struct Space4XRunMetaUnlockRecord : IBufferElementData
+    {
+        public FixedString64Bytes UnlockId;
+        public Space4XRunMetaUnlockFlags Flag;
+        public uint Tick;
+    }
+
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(Space4XRunChainLightningSystem))]
+    public partial struct Space4XFleetcrawlMetaProficiencySystem : ISystem
+    {
+        private ComponentLookup<Space4XRunPlayerTag> _playerTagLookup;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Space4XFleetcrawlDirectorState>();
+            state.RequireForUpdate<TimeState>();
+            state.RequireForUpdate<RewindState>();
+            _playerTagLookup = state.GetComponentLookup<Space4XRunPlayerTag>(true);
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var time = SystemAPI.GetSingleton<TimeState>();
+            var rewind = SystemAPI.GetSingleton<RewindState>();
+            if (time.IsPaused || rewind.Mode != RewindMode.Record)
+            {
+                return;
+            }
+
+            if (!SystemAPI.TryGetSingletonEntity<Space4XFleetcrawlDirectorState>(out var directorEntity))
+            {
+                return;
+            }
+
+            EnsureDirectorState(ref state, directorEntity);
+
+            var em = state.EntityManager;
+            var meta = em.GetComponentData<Space4XRunMetaProficiencyState>(directorEntity);
+            var config = em.GetComponentData<Space4XRunMetaProficiencyConfig>(directorEntity);
+            var unlockState = em.GetComponentData<Space4XRunMetaUnlockState>(directorEntity);
+            var unlockRecords = em.GetBuffer<Space4XRunMetaUnlockRecord>(directorEntity);
+            var deltaSeconds = ResolveDeltaSeconds(time);
+
+            _playerTagLookup.Update(ref state);
+            EnsureDamageEventCursors(ref state);
+
+            foreach (var focus in SystemAPI.Query<RefRO<ShipPowerFocus>>().WithAll<Space4XRunPlayerTag>())
+            {
+                if (focus.ValueRO.Mode == ShipPowerFocusMode.Stealth)
+                {
+                    ProgressionMath.AccumulatePositive(ref meta.CloakSeconds, deltaSeconds);
+                }
+            }
+
+            foreach (var request in SystemAPI.Query<RefRO<TimeStopRequest>>().WithAll<Space4XRunPlayerTag>())
+            {
+                ProgressionMath.AccumulatePositive(ref meta.TimeStopRequestedSeconds, request.ValueRO.DurationSeconds);
+            }
+
+            foreach (var (events, side, cursor) in SystemAPI.Query<DynamicBuffer<DamageEvent>, RefRO<ScenarioSide>, RefRW<Space4XRunMetaDamageEventCursor>>()
+                         .WithAny<Space4XRunPlayerTag, Space4XRunEnemyTag>())
+            {
+                var from = math.clamp(cursor.ValueRO.ProcessedCount, 0, events.Length);
+                var to = events.Length;
+                for (var i = from; i < to; i++)
+                {
+                    var evt = events[i];
+                    if (evt.Source == Entity.Null)
+                    {
+                        continue;
+                    }
+
+                    var damageType = Space4XWeapon.ResolveDamageType(evt.WeaponType);
+                    var appliedDamage = math.max(0f, evt.ShieldDamage + evt.ArmorDamage + evt.HullDamage);
+
+                    if (side.ValueRO.Side == 1 && _playerTagLookup.HasComponent(evt.Source))
+                    {
+                        AccumulateDamage(ref meta, damageType, appliedDamage, dealt: true);
+                        if (evt.WeaponType == WeaponType.Missile)
+                        {
+                            ProgressionMath.AccumulatePositive(ref meta.MissileDamageDealt, appliedDamage);
+                        }
+                    }
+                    else if (side.ValueRO.Side == 0 && !_playerTagLookup.HasComponent(evt.Source))
+                    {
+                        var mitigated = math.max(0f, evt.RawDamage - appliedDamage);
+                        AccumulateDamage(ref meta, damageType, mitigated, dealt: false);
+                    }
+                }
+
+                cursor.ValueRW.ProcessedCount = events.Length;
+            }
+
+            var resolvedFlags = ResolveUnlockFlags(in meta, in config);
+            var addedFlags = resolvedFlags & ~unlockState.Flags;
+            if (addedFlags != Space4XRunMetaUnlockFlags.None)
+            {
+                unlockState.Flags = resolvedFlags;
+                unlockState.UnlockCount = (byte)math.min(255, math.countbits((uint)(ushort)unlockState.Flags));
+                AppendUnlockRecords(unlockRecords, addedFlags, time.Tick);
+                Debug.Log($"[FleetcrawlMeta] UNLOCK flags={unlockState.Flags} count={unlockState.UnlockCount} tick={time.Tick}.");
+            }
+
+            em.SetComponentData(directorEntity, meta);
+            em.SetComponentData(directorEntity, unlockState);
+        }
+
+        private static void EnsureDirectorState(ref SystemState state, Entity directorEntity)
+        {
+            var em = state.EntityManager;
+            if (!em.HasComponent<Space4XRunMetaProficiencyState>(directorEntity))
+            {
+                em.AddComponentData(directorEntity, new Space4XRunMetaProficiencyState());
+            }
+
+            if (!em.HasComponent<Space4XRunMetaProficiencyConfig>(directorEntity))
+            {
+                em.AddComponentData(directorEntity, Space4XRunMetaProficiencyConfig.Default);
+            }
+
+            if (!em.HasComponent<Space4XRunMetaUnlockState>(directorEntity))
+            {
+                em.AddComponentData(directorEntity, new Space4XRunMetaUnlockState());
+            }
+
+            if (!em.HasBuffer<Space4XRunMetaUnlockRecord>(directorEntity))
+            {
+                em.AddBuffer<Space4XRunMetaUnlockRecord>(directorEntity);
+            }
+        }
+
+        private static void EnsureDamageEventCursors(ref SystemState state)
+        {
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            foreach (var (_, _, entity) in SystemAPI.Query<DynamicBuffer<DamageEvent>, RefRO<ScenarioSide>>()
+                         .WithAny<Space4XRunPlayerTag, Space4XRunEnemyTag>()
+                         .WithNone<Space4XRunMetaDamageEventCursor>()
+                         .WithEntityAccess())
+            {
+                ecb.AddComponent(entity, new Space4XRunMetaDamageEventCursor { ProcessedCount = 0 });
+            }
+
+            ecb.Playback(state.EntityManager);
+            ecb.Dispose();
+        }
+
+        private static float ResolveDeltaSeconds(in TimeState time)
+        {
+            if (time.FixedDeltaTime > 0f)
+            {
+                return time.FixedDeltaTime;
+            }
+
+            if (time.DeltaSeconds > 0f)
+            {
+                return time.DeltaSeconds;
+            }
+
+            return 1f / 60f;
+        }
+
+        private static void AccumulateDamage(ref Space4XRunMetaProficiencyState state, Space4XDamageType damageType, float amount, bool dealt)
+        {
+            if (amount <= 0f)
+            {
+                return;
+            }
+
+            switch (damageType)
+            {
+                case Space4XDamageType.Energy:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtEnergy, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedEnergy, amount);
+                    break;
+                case Space4XDamageType.Thermal:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtThermal, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedThermal, amount);
+                    break;
+                case Space4XDamageType.EM:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtEM, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedEM, amount);
+                    break;
+                case Space4XDamageType.Radiation:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtRadiation, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedRadiation, amount);
+                    break;
+                case Space4XDamageType.Caustic:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtCaustic, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedCaustic, amount);
+                    break;
+                case Space4XDamageType.Kinetic:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtKinetic, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedKinetic, amount);
+                    break;
+                case Space4XDamageType.Explosive:
+                    if (dealt) ProgressionMath.AccumulatePositive(ref state.DamageDealtExplosive, amount);
+                    else ProgressionMath.AccumulatePositive(ref state.DamageMitigatedExplosive, amount);
+                    break;
+            }
+        }
+
+        private static Space4XRunMetaUnlockFlags ResolveUnlockFlags(
+            in Space4XRunMetaProficiencyState state,
+            in Space4XRunMetaProficiencyConfig config)
+        {
+            var flags = Space4XRunMetaUnlockFlags.None;
+
+            var dealtTotal = state.DamageDealtEnergy +
+                             state.DamageDealtThermal +
+                             state.DamageDealtEM +
+                             state.DamageDealtRadiation +
+                             state.DamageDealtCaustic +
+                             state.DamageDealtKinetic +
+                             state.DamageDealtExplosive;
+            var mitigatedTotal = state.DamageMitigatedEnergy +
+                                 state.DamageMitigatedThermal +
+                                 state.DamageMitigatedEM +
+                                 state.DamageMitigatedRadiation +
+                                 state.DamageMitigatedCaustic +
+                                 state.DamageMitigatedKinetic +
+                                 state.DamageMitigatedExplosive;
+
+            if (dealtTotal >= config.DamageThreshold) flags |= Space4XRunMetaUnlockFlags.DamageTypeSpecialist;
+            if (mitigatedTotal >= config.MitigationThreshold) flags |= Space4XRunMetaUnlockFlags.MitigationSpecialist;
+            if (state.CloakSeconds >= config.CloakSecondsThreshold) flags |= Space4XRunMetaUnlockFlags.CloakOperator;
+            if (state.TimeStopRequestedSeconds >= config.TimeStopSecondsThreshold) flags |= Space4XRunMetaUnlockFlags.ChronoOperator;
+            if (state.MissileDamageDealt >= config.MissileDamageThreshold) flags |= Space4XRunMetaUnlockFlags.OrdnanceSpecialist;
+            if (state.CraftShotDown >= config.CraftShotDownThreshold) flags |= Space4XRunMetaUnlockFlags.InterceptorSpecialist;
+            if (state.CapitalShipsDestroyed >= config.CapitalShipsDestroyedThreshold) flags |= Space4XRunMetaUnlockFlags.CapitalHunter;
+            if (state.HiddenCachesFound >= config.HiddenCachesFoundThreshold) flags |= Space4XRunMetaUnlockFlags.CacheHunter;
+
+            return flags;
+        }
+
+        private static void AppendUnlockRecords(
+            DynamicBuffer<Space4XRunMetaUnlockRecord> records,
+            Space4XRunMetaUnlockFlags addedFlags,
+            uint tick)
+        {
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.DamageTypeSpecialist, new FixedString64Bytes("meta_unlock_damage_type_specialist"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.MitigationSpecialist, new FixedString64Bytes("meta_unlock_mitigation_specialist"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.CloakOperator, new FixedString64Bytes("meta_unlock_cloak_operator"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.ChronoOperator, new FixedString64Bytes("meta_unlock_chrono_operator"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.OrdnanceSpecialist, new FixedString64Bytes("meta_unlock_ordnance_specialist"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.InterceptorSpecialist, new FixedString64Bytes("meta_unlock_interceptor_specialist"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.CapitalHunter, new FixedString64Bytes("meta_unlock_capital_hunter"), tick);
+            AppendUnlockRecord(records, addedFlags, Space4XRunMetaUnlockFlags.CacheHunter, new FixedString64Bytes("meta_unlock_cache_hunter"), tick);
+        }
+
+        private static void AppendUnlockRecord(
+            DynamicBuffer<Space4XRunMetaUnlockRecord> records,
+            Space4XRunMetaUnlockFlags addedFlags,
+            Space4XRunMetaUnlockFlags flag,
+            in FixedString64Bytes unlockId,
+            uint tick)
+        {
+            if ((addedFlags & flag) == 0)
+            {
+                return;
+            }
+
+            for (var i = 0; i < records.Length; i++)
+            {
+                if (records[i].Flag == flag)
+                {
+                    return;
+                }
+            }
+
+            records.Add(new Space4XRunMetaUnlockRecord
+            {
+                UnlockId = unlockId,
+                Flag = flag,
+                Tick = tick
+            });
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
@@ -245,6 +245,42 @@ namespace Space4x.Scenario
             em.AddComponentData(e, Space4XShield.Standard(side == 1 ? 620f : 680f));
             em.AddComponentData(e, Space4XArmor.Standard(side == 1 ? 52f : 58f));
             em.AddComponentData(e, SupplyStatus.DefaultCarrier);
+            em.AddComponentData(e, new ShipReactorSpec
+            {
+                Type = side == 1 ? Space4XReactorType.FusionStandard : Space4XReactorType.FusionHeavy,
+                OutputMW = side == 1 ? 2600f : 3600f,
+                Efficiency = side == 1 ? 0.85f : 0.9f,
+                IdleDrawMW = side == 1 ? 320f : 380f,
+                HotRestartSeconds = 1f,
+                ColdRestartSeconds = 50f
+            });
+            em.AddComponentData(e, new RestartState
+            {
+                Warmth = 1f,
+                RestartTimer = 0f,
+                Mode = RestartMode.Hot
+            });
+            var specialEnergyConfig = ShipSpecialEnergyConfig.Default;
+            var specialEnergyMax = math.max(
+                0f,
+                specialEnergyConfig.BaseMax + math.max(0f, (side == 1 ? 2600f : 3600f)) * specialEnergyConfig.ReactorOutputToMax);
+            var specialEnergyRegen = math.max(
+                0f,
+                specialEnergyConfig.BaseRegenPerSecond + math.max(0f, (side == 1 ? 2600f : 3600f)) * specialEnergyConfig.ReactorOutputToRegen);
+            specialEnergyRegen *= math.max(0f, side == 1 ? 0.85f : 0.9f) * specialEnergyConfig.ReactorEfficiencyRegenMultiplier;
+            em.AddComponentData(e, specialEnergyConfig);
+            em.AddComponentData(e, new ShipSpecialEnergyState
+            {
+                Current = specialEnergyMax,
+                EffectiveMax = specialEnergyMax,
+                EffectiveRegenPerSecond = specialEnergyRegen,
+                LastSpent = 0f,
+                LastSpendTick = 0,
+                FailedSpendAttempts = 0,
+                LastUpdatedTick = 0
+            });
+            em.AddBuffer<ShipSpecialEnergyPassiveModifier>(e);
+            em.AddBuffer<ShipSpecialEnergySpendRequest>(e);
             EnsureSubsystems(ref state, e, hull.Max);
             em.AddComponentData(e, new Space4XEngagement
             {

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialEnergyRules.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialEnergyRules.cs
@@ -1,0 +1,7 @@
+namespace Space4x.Scenario
+{
+    public static class Space4XFleetcrawlSpecialEnergyRules
+    {
+        public const float SpecialAbilityCost = 32f;
+    }
+}

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialEnergyRules.cs.meta
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialEnergyRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9c09ae9941b4c76a6226b1d2c3ad926

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlUiOverlayMono.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlUiOverlayMono.cs
@@ -102,7 +102,7 @@ namespace Space4x.Scenario
 
             var status = Space4XFleetcrawlPlayerControlMono.CurrentStatus;
             GUILayout.Label(
-                $"Pilot: boost={status.Boost01 * 100f:0}%  dash_cd={status.DashCooldown:0.00}s  speed={status.Speed:0.0}",
+                $"Pilot: boost={status.Boost01 * 100f:0}%  dash_cd={status.DashCooldown:0.00}s  speed={status.Speed:0.0}  special={status.SpecialEnergyCurrent:0.#}/{status.SpecialEnergyMax:0.#} ({status.SpecialEnergy01 * 100f:0}%)",
                 _labelStyle);
             GUILayout.Label("Controls: WASD move, Space/Ctrl vertical, Shift boost, Q dash, E special, F snap camera, Mouse wheel zoom", _labelStyle);
 

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XCelestialManipulationSystems.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XCelestialManipulationSystems.cs
@@ -31,6 +31,7 @@ namespace Space4X.Systems.Interaction
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<TimeState>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
             _celestialLookup = state.GetComponentLookup<Space4XCelestialManipulable>(true);
             _holdLookup = state.GetComponentLookup<Space4XCelestialHoldState>(false);
             _heldLookup = state.GetComponentLookup<HandHeldTag>(true);
@@ -40,6 +41,12 @@ namespace Space4X.Systems.Interaction
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var timeState = SystemAPI.GetSingleton<TimeState>();
             uint currentTick = timeState.Tick;
             var ecb = new EntityCommandBuffer(Allocator.Temp);
@@ -168,11 +175,18 @@ namespace Space4X.Systems.Interaction
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<TimeState>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
         }
 
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var timeState = SystemAPI.GetSingleton<TimeState>();
             float deltaTime = timeState.FixedDeltaTime > 0f ? timeState.FixedDeltaTime : timeState.DeltaTime;
 

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs
@@ -1,0 +1,121 @@
+using PureDOTS.Runtime.Components;
+using PureDOTS.Runtime.Hand;
+using PureDOTS.Runtime.Interaction;
+using PureDOTS.Runtime.Physics;
+using Space4X.Runtime.Interaction;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Space4X.Systems.Interaction
+{
+    /// <summary>
+    /// Performs one-shot cleanup when leaving Divine Hand mode.
+    /// Prevents sticky held entities, queued throws, and stale hand commands across mode switches.
+    /// </summary>
+    [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
+    [UpdateBefore(typeof(Space4XHandCommandStateSystem))]
+    [UpdateBefore(typeof(Space4XPickupSystem))]
+    [UpdateBefore(typeof(Space4XThrowSystem))]
+    [UpdateBefore(typeof(Space4XThrowQueueSystem))]
+    [UpdateBefore(typeof(Space4XHeldFollowSystem))]
+    [UpdateBefore(typeof(Space4XCelestialHandCommandSystem))]
+    public partial struct Space4XDivineHandModeExitCleanupSystem : ISystem
+    {
+        private byte _wasDivineHandActive;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
+            state.RequireForUpdate<HandState>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            bool divineActive = modeState.IsDivineHandEnabled != 0;
+            if (divineActive)
+            {
+                _wasDivineHandActive = 1;
+                return;
+            }
+
+            if (_wasDivineHandActive == 0)
+            {
+                return;
+            }
+
+            _wasDivineHandActive = 0;
+
+            var em = state.EntityManager;
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+            foreach (var (handStateRef, commandBuffer, handEntity) in
+                     SystemAPI.Query<RefRW<HandState>, DynamicBuffer<HandCommand>>().WithEntityAccess())
+            {
+                var handState = handStateRef.ValueRO;
+                commandBuffer.Clear();
+
+                if (em.HasBuffer<ThrowQueue>(handEntity))
+                {
+                    em.GetBuffer<ThrowQueue>(handEntity).Clear();
+                }
+
+                ForceReleaseHeldEntity(ref ecb, em, handState.HeldEntity);
+
+                handState.HeldEntity = Entity.Null;
+                handState.CurrentState = HandStateType.Idle;
+                handState.PreviousState = HandStateType.Idle;
+                handState.ChargeTimer = 0f;
+                handState.CooldownTimer = 0f;
+                handState.StateTimer = 0;
+                handStateRef.ValueRW = handState;
+            }
+
+            foreach (var pickupStateRef in SystemAPI.Query<RefRW<PickupState>>().WithAll<Space4XGodHandTag>())
+            {
+                var pickupState = pickupStateRef.ValueRO;
+                ForceReleaseHeldEntity(ref ecb, em, pickupState.TargetEntity);
+
+                pickupState.State = PickupStateType.Empty;
+                pickupState.TargetEntity = Entity.Null;
+                pickupState.CursorMovementAccumulator = 0f;
+                pickupState.HoldTime = 0f;
+                pickupState.HoldDistance = 0f;
+                pickupState.AccumulatedVelocity = Unity.Mathematics.float3.zero;
+                pickupState.IsMoving = false;
+                pickupStateRef.ValueRW = pickupState;
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+
+        private static void ForceReleaseHeldEntity(ref EntityCommandBuffer ecb, EntityManager entityManager, Entity heldEntity)
+        {
+            if (heldEntity == Entity.Null || !entityManager.Exists(heldEntity))
+            {
+                return;
+            }
+
+            if (entityManager.HasComponent<HandHeldTag>(heldEntity))
+            {
+                ecb.RemoveComponent<HandHeldTag>(heldEntity);
+            }
+
+            if (entityManager.HasComponent<HeldByPlayer>(heldEntity))
+            {
+                ecb.SetComponentEnabled<HeldByPlayer>(heldEntity, false);
+            }
+
+            if (entityManager.HasComponent<MovementSuppressed>(heldEntity))
+            {
+                ecb.SetComponentEnabled<MovementSuppressed>(heldEntity, false);
+            }
+
+            if (entityManager.HasComponent<Space4XCelestialHoldState>(heldEntity))
+            {
+                ecb.RemoveComponent<Space4XCelestialHoldState>(heldEntity);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs.meta
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8ebdfb08ba14222bff7ca634e92e5ab

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XHandCommandStateSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XHandCommandStateSystem.cs
@@ -33,6 +33,7 @@ namespace Space4X.Systems.Interaction
             state.RequireForUpdate<HandInputFrame>();
             state.RequireForUpdate<HandAffordances>();
             state.RequireForUpdate<HandStateData>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
             _pickableLookup = state.GetComponentLookup<HandPickable>(true);
             _spacePickableLookup = state.GetComponentLookup<Space4XHandPickable>(true);
             _massLookup = state.GetComponentLookup<PhysicsMass>(true);
@@ -42,6 +43,12 @@ namespace Space4X.Systems.Interaction
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var input = SystemAPI.GetSingleton<HandInputFrame>();
             var affordances = SystemAPI.GetSingleton<HandAffordances>();
             var timeState = SystemAPI.GetSingleton<TimeState>();

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XHeldFollowSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XHeldFollowSystem.cs
@@ -31,6 +31,7 @@ namespace Space4X.Systems.Interaction
             state.RequireForUpdate<TimeState>();
             state.RequireForUpdate<RewindState>();
             state.RequireForUpdate<HandInputFrame>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
 
             _transformLookup = state.GetComponentLookup<LocalTransform>(false);
             _pickupStateLookup = state.GetComponentLookup<PickupState>(true);
@@ -40,6 +41,12 @@ namespace Space4X.Systems.Interaction
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var timeState = SystemAPI.GetSingleton<TimeState>();
             var rewindState = SystemAPI.GetSingleton<RewindState>();
 

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XPickupSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XPickupSystem.cs
@@ -40,6 +40,7 @@ namespace Space4X.Systems.Interaction
             state.RequireForUpdate<PhysicsConfig>();
             state.RequireForUpdate<HandInputFrame>();
             state.RequireForUpdate<HandHover>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
 
             _pickableLookup = state.GetComponentLookup<Pickable>(true);
             _transformLookup = state.GetComponentLookup<LocalTransform>(true);
@@ -61,6 +62,12 @@ namespace Space4X.Systems.Interaction
 
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var timeState = SystemAPI.GetSingleton<TimeState>();
             var rewindState = SystemAPI.GetSingleton<RewindState>();
 

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XThrowQueueSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XThrowQueueSystem.cs
@@ -31,6 +31,7 @@ namespace Space4X.Systems.Interaction
             state.RequireForUpdate<TimeState>();
             state.RequireForUpdate<RewindState>();
             state.RequireForUpdate<HandInputFrame>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
 
             _transformLookup = state.GetComponentLookup<LocalTransform>(true);
             _physicsVelocityLookup = state.GetComponentLookup<Unity.Physics.PhysicsVelocity>(false);
@@ -51,6 +52,12 @@ namespace Space4X.Systems.Interaction
 
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var timeState = SystemAPI.GetSingleton<TimeState>();
             var rewindState = SystemAPI.GetSingleton<RewindState>();
 

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XThrowSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XThrowSystem.cs
@@ -39,6 +39,7 @@ namespace Space4X.Systems.Interaction
             state.RequireForUpdate<RewindState>();
             state.RequireForUpdate<HandInputFrame>();
             state.RequireForUpdate<HandHover>();
+            state.RequireForUpdate<Space4XControlModeRuntimeState>();
 
             _transformLookup = state.GetComponentLookup<LocalTransform>(true);
             _physicsVelocityLookup = state.GetComponentLookup<Unity.Physics.PhysicsVelocity>(false);
@@ -64,6 +65,12 @@ namespace Space4X.Systems.Interaction
 
         public void OnUpdate(ref SystemState state)
         {
+            var modeState = SystemAPI.GetSingleton<Space4XControlModeRuntimeState>();
+            if (modeState.IsDivineHandEnabled == 0)
+            {
+                return;
+            }
+
             var timeState = SystemAPI.GetSingleton<TimeState>();
             var rewindState = SystemAPI.GetSingleton<RewindState>();
 

--- a/Assets/Scripts/Space4x/Systems/Power/Space4XShipSpecialEnergySystems.cs
+++ b/Assets/Scripts/Space4x/Systems/Power/Space4XShipSpecialEnergySystems.cs
@@ -1,0 +1,208 @@
+using PureDOTS.Runtime.Components;
+using PureDOTS.Runtime.Math;
+using PureDOTS.Systems;
+using Space4X.Runtime;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Space4X.Systems.Power
+{
+    [BurstCompile]
+    [UpdateInGroup(typeof(InitializationSystemGroup))]
+    public partial struct Space4XShipSpecialEnergyBootstrapSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<ShipReactorSpec>();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            var em = state.EntityManager;
+
+            foreach (var (reactor, entity) in SystemAPI.Query<RefRO<ShipReactorSpec>>().WithEntityAccess())
+            {
+                var config = em.HasComponent<ShipSpecialEnergyConfig>(entity)
+                    ? em.GetComponentData<ShipSpecialEnergyConfig>(entity)
+                    : ShipSpecialEnergyConfig.Default;
+
+                if (!em.HasComponent<ShipSpecialEnergyConfig>(entity))
+                {
+                    ecb.AddComponent(entity, config);
+                }
+
+                if (!em.HasComponent<ShipSpecialEnergyState>(entity))
+                {
+                    var baseMax = ResolveBaseMax(reactor.ValueRO, config);
+                    var baseRegen = ResolveBaseRegen(reactor.ValueRO, config);
+                    ecb.AddComponent(entity, new ShipSpecialEnergyState
+                    {
+                        Current = baseMax,
+                        EffectiveMax = baseMax,
+                        EffectiveRegenPerSecond = baseRegen,
+                        LastSpent = 0f,
+                        LastSpendTick = 0,
+                        FailedSpendAttempts = 0,
+                        LastUpdatedTick = 0
+                    });
+                }
+
+                if (!em.HasBuffer<ShipSpecialEnergyPassiveModifier>(entity))
+                {
+                    ecb.AddBuffer<ShipSpecialEnergyPassiveModifier>(entity);
+                }
+
+                if (!em.HasBuffer<ShipSpecialEnergySpendRequest>(entity))
+                {
+                    ecb.AddBuffer<ShipSpecialEnergySpendRequest>(entity);
+                }
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+
+        private static float ResolveBaseMax(in ShipReactorSpec reactor, in ShipSpecialEnergyConfig config)
+        {
+            var output = math.max(0f, reactor.OutputMW);
+            var outputToMax = math.max(0f, config.ReactorOutputToMax);
+            return math.max(0f, config.BaseMax + output * outputToMax);
+        }
+
+        private static float ResolveBaseRegen(in ShipReactorSpec reactor, in ShipSpecialEnergyConfig config)
+        {
+            var output = math.max(0f, reactor.OutputMW);
+            var outputToRegen = math.max(0f, config.ReactorOutputToRegen);
+            var regen = math.max(0f, config.BaseRegenPerSecond + output * outputToRegen);
+            var efficiencyScale = math.max(0f, reactor.Efficiency) * math.max(0f, config.ReactorEfficiencyRegenMultiplier);
+            return math.max(0f, regen * efficiencyScale);
+        }
+    }
+
+    [BurstCompile]
+    [UpdateInGroup(typeof(PowerSystemGroup))]
+    [UpdateAfter(typeof(Space4XShipPowerAllocationSyncSystem))]
+    public partial struct Space4XShipSpecialEnergySystem : ISystem
+    {
+        private ComponentLookup<RestartState> _restartLookup;
+        private BufferLookup<ShipSpecialEnergyPassiveModifier> _passiveLookup;
+        private BufferLookup<ShipSpecialEnergySpendRequest> _spendLookup;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<ShipSpecialEnergyState>();
+            state.RequireForUpdate<ShipSpecialEnergyConfig>();
+            state.RequireForUpdate<ShipReactorSpec>();
+            state.RequireForUpdate<TimeState>();
+            _restartLookup = state.GetComponentLookup<RestartState>(true);
+            _passiveLookup = state.GetBufferLookup<ShipSpecialEnergyPassiveModifier>(true);
+            _spendLookup = state.GetBufferLookup<ShipSpecialEnergySpendRequest>(false);
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            var time = SystemAPI.GetSingleton<TimeState>();
+            if (time.IsPaused)
+            {
+                return;
+            }
+
+            var deltaTime = math.max(0f, time.FixedDeltaTime);
+            _restartLookup.Update(ref state);
+            _passiveLookup.Update(ref state);
+            _spendLookup.Update(ref state);
+
+            foreach (var (reactor, config, energy, entity) in
+                     SystemAPI.Query<RefRO<ShipReactorSpec>, RefRO<ShipSpecialEnergyConfig>, RefRW<ShipSpecialEnergyState>>().WithEntityAccess())
+            {
+                var additiveMax = 0f;
+                var multiplicativeMax = 1f;
+                var additiveRegen = 0f;
+                var multiplicativeRegen = 1f;
+
+                if (_passiveLookup.HasBuffer(entity))
+                {
+                    var modifiers = _passiveLookup[entity];
+                    for (var i = 0; i < modifiers.Length; i++)
+                    {
+                        var modifier = modifiers[i];
+                        additiveMax += modifier.AdditiveMax;
+                        multiplicativeMax *= modifier.MultiplicativeMax <= 0f ? 1f : modifier.MultiplicativeMax;
+                        additiveRegen += modifier.AdditiveRegenPerSecond;
+                        multiplicativeRegen *= modifier.MultiplicativeRegen <= 0f ? 1f : modifier.MultiplicativeRegen;
+                    }
+                }
+
+                var baseMax = ResolveBaseMax(reactor.ValueRO, config.ValueRO);
+                var baseRegen = ResolveBaseRegen(reactor.ValueRO, config.ValueRO);
+
+                if (_restartLookup.HasComponent(entity))
+                {
+                    var restart = _restartLookup[entity];
+                    if (restart.RestartTimer > 0.01f)
+                    {
+                        baseRegen *= math.clamp(config.ValueRO.RestartRegenPenaltyMultiplier, 0f, 1f);
+                    }
+                }
+
+                var effectiveMax = ResourcePoolMath.ResolveModifiedMax(baseMax, additiveMax, multiplicativeMax);
+                var effectiveRegen = ResourcePoolMath.ResolveModifiedRate(baseRegen, additiveRegen, multiplicativeRegen);
+                var current = ResourcePoolMath.ClampCurrent(energy.ValueRO.Current, effectiveMax);
+                var spentThisTick = energy.ValueRO.LastSpendTick == time.Tick
+                    ? math.max(0f, energy.ValueRO.LastSpent)
+                    : 0f;
+                var failedAttempts = energy.ValueRO.FailedSpendAttempts;
+
+                if (_spendLookup.HasBuffer(entity))
+                {
+                    var requests = _spendLookup[entity];
+                    var activationCostScale = math.max(0.05f, config.ValueRO.ActivationCostMultiplier);
+                    for (var i = 0; i < requests.Length; i++)
+                    {
+                        var requestedAmount = math.max(0f, requests[i].Amount) * activationCostScale;
+                        if (ResourcePoolMath.TrySpend(ref current, requestedAmount))
+                        {
+                            spentThisTick += requestedAmount;
+                        }
+                        else if (requestedAmount > 0f)
+                        {
+                            failedAttempts = (ushort)math.min((int)ushort.MaxValue, failedAttempts + 1);
+                        }
+                    }
+
+                    requests.Clear();
+                }
+
+                current = ResourcePoolMath.Regen(current, effectiveMax, effectiveRegen, deltaTime);
+                energy.ValueRW.Current = current;
+                energy.ValueRW.EffectiveMax = effectiveMax;
+                energy.ValueRW.EffectiveRegenPerSecond = effectiveRegen;
+                energy.ValueRW.LastSpent = spentThisTick;
+                energy.ValueRW.LastSpendTick = spentThisTick > 0f ? time.Tick : energy.ValueRO.LastSpendTick;
+                energy.ValueRW.FailedSpendAttempts = failedAttempts;
+                energy.ValueRW.LastUpdatedTick = time.Tick;
+            }
+        }
+
+        private static float ResolveBaseMax(in ShipReactorSpec reactor, in ShipSpecialEnergyConfig config)
+        {
+            var output = math.max(0f, reactor.OutputMW);
+            var outputToMax = math.max(0f, config.ReactorOutputToMax);
+            return math.max(0f, config.BaseMax + output * outputToMax);
+        }
+
+        private static float ResolveBaseRegen(in ShipReactorSpec reactor, in ShipSpecialEnergyConfig config)
+        {
+            var output = math.max(0f, reactor.OutputMW);
+            var outputToRegen = math.max(0f, config.ReactorOutputToRegen);
+            var regen = math.max(0f, config.BaseRegenPerSecond + output * outputToRegen);
+            var efficiencyScale = math.max(0f, reactor.Efficiency) * math.max(0f, config.ReactorEfficiencyRegenMultiplier);
+            return math.max(0f, regen * efficiencyScale);
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Systems/Power/Space4XShipSpecialEnergySystems.cs.meta
+++ b/Assets/Scripts/Space4x/Systems/Power/Space4XShipSpecialEnergySystems.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b20d3cefbc114c2f99a3beddc0c2b53a

--- a/Assets/Scripts/Space4x/Systems/Space4XContextOrderSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Space4XContextOrderSystem.cs
@@ -38,6 +38,16 @@ namespace Space4X.Systems
                 return;
 
             var rightClicks = state.EntityManager.GetBuffer<RightClickEvent>(inputEntity);
+            if (Space4XControlModeState.CurrentMode != Space4XControlMode.Rts)
+            {
+                if (rightClicks.Length > 0)
+                {
+                    rightClicks.Clear();
+                }
+
+                return;
+            }
+
             if (rightClicks.Length == 0)
                 return;
             using var rightClickEvents = rightClicks.ToNativeArray(Allocator.Temp);

--- a/Assets/Scripts/Space4x/Tests/PureDotsProgressionMathTests.cs
+++ b/Assets/Scripts/Space4x/Tests/PureDotsProgressionMathTests.cs
@@ -1,0 +1,57 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using PureDOTS.Runtime.Progression;
+
+namespace Space4X.Tests
+{
+    public sealed class PureDotsProgressionMathTests
+    {
+        [Test]
+        public void ResolveSkill01FromPractice_ScalesByWisdomAndAptitude()
+        {
+            var novice = ProgressionMath.ResolveSkill01FromPractice(
+                practiceSeconds: 300f,
+                secondsToMastery: 1200f,
+                wisdom01: 0f,
+                aptitude01: 0f,
+                wisdomMultiplierMin: 0.8f,
+                wisdomMultiplierMax: 1.2f,
+                aptitudeMultiplierMin: 0.8f,
+                aptitudeMultiplierMax: 1.2f);
+            var veteran = ProgressionMath.ResolveSkill01FromPractice(
+                practiceSeconds: 300f,
+                secondsToMastery: 1200f,
+                wisdom01: 1f,
+                aptitude01: 1f,
+                wisdomMultiplierMin: 0.8f,
+                wisdomMultiplierMax: 1.2f,
+                aptitudeMultiplierMin: 0.8f,
+                aptitudeMultiplierMax: 1.2f);
+
+            Assert.Greater(veteran, novice);
+            Assert.LessOrEqual(veteran, 1f);
+        }
+
+        [Test]
+        public void ResolveLinearMilestoneCount_CountsReachedThresholds()
+        {
+            var count = ProgressionMath.ResolveLinearMilestoneCount(
+                totalValue: 35f,
+                baseThreshold: 10f,
+                perMilestoneStep: 10f,
+                maxMilestones: 8);
+
+            Assert.AreEqual(3, count);
+        }
+
+        [Test]
+        public void AccumulatePositive_IgnoresNegativeDelta()
+        {
+            var value = 7f;
+            ProgressionMath.AccumulatePositive(ref value, -2f);
+            ProgressionMath.AccumulatePositive(ref value, 3f);
+            Assert.AreEqual(10f, value, 1e-4f);
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Space4x/Tests/PureDotsResourcePoolMathTests.cs
+++ b/Assets/Scripts/Space4x/Tests/PureDotsResourcePoolMathTests.cs
@@ -1,0 +1,36 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using PureDOTS.Runtime.Math;
+
+namespace Space4X.Tests
+{
+    public sealed class PureDotsResourcePoolMathTests
+    {
+        [Test]
+        public void ResolveModifiedMax_AppliesAdditiveAndMultiplicativeModifiers()
+        {
+            var max = ResourcePoolMath.ResolveModifiedMax(100f, -20f, 0.75f);
+            Assert.AreEqual(60f, max, 1e-4f);
+        }
+
+        [Test]
+        public void Regen_RespectsCapAndDeltaTime()
+        {
+            var current = ResourcePoolMath.Regen(10f, 20f, 4f, 1.5f);
+            Assert.AreEqual(16f, current, 1e-4f);
+
+            var capped = ResourcePoolMath.Regen(19f, 20f, 4f, 1f);
+            Assert.AreEqual(20f, capped, 1e-4f);
+        }
+
+        [Test]
+        public void TrySpend_FailsWhenInsufficient()
+        {
+            var current = 5f;
+            var spent = ResourcePoolMath.TrySpend(ref current, 8f);
+            Assert.IsFalse(spent);
+            Assert.AreEqual(5f, current, 1e-4f);
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Space4x/Tests/PureDotsResourcePoolMathTests.cs
+++ b/Assets/Scripts/Space4x/Tests/PureDotsResourcePoolMathTests.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR || UNITY_INCLUDE_TESTS
 using NUnit.Framework;
 using PureDOTS.Runtime.Math;
+using PureDOTS.Runtime.Resources;
 
 namespace Space4X.Tests
 {
@@ -30,6 +31,31 @@ namespace Space4X.Tests
             var spent = ResourcePoolMath.TrySpend(ref current, 8f);
             Assert.IsFalse(spent);
             Assert.AreEqual(5f, current, 1e-4f);
+        }
+
+        [Test]
+        public void AccumulateModifier_UsesMultiplicativeComposition()
+        {
+            var accumulator = ResourcePoolModifier.Identity;
+            ResourcePoolMath.AccumulateModifier(ref accumulator, new ResourcePoolModifier
+            {
+                AdditiveMax = 10f,
+                MultiplicativeMax = 1.2f,
+                AdditiveRegenPerSecond = 1f,
+                MultiplicativeRegen = 0.9f
+            });
+            ResourcePoolMath.AccumulateModifier(ref accumulator, new ResourcePoolModifier
+            {
+                AdditiveMax = -5f,
+                MultiplicativeMax = 0.5f,
+                AdditiveRegenPerSecond = 2f,
+                MultiplicativeRegen = 1.1f
+            });
+
+            Assert.AreEqual(5f, accumulator.AdditiveMax, 1e-4f);
+            Assert.AreEqual(0.6f, accumulator.MultiplicativeMax, 1e-4f);
+            Assert.AreEqual(3f, accumulator.AdditiveRegenPerSecond, 1e-4f);
+            Assert.AreEqual(0.99f, accumulator.MultiplicativeRegen, 1e-4f);
         }
     }
 }

--- a/Assets/Scripts/Space4x/Tests/PureDotsResourcePoolMathTests.cs.meta
+++ b/Assets/Scripts/Space4x/Tests/PureDotsResourcePoolMathTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4664a2775724b6badbfd7fa9642ac52

--- a/Assets/Scripts/Space4x/Tests/PureDotsSegmentGeometryTests.cs
+++ b/Assets/Scripts/Space4x/Tests/PureDotsSegmentGeometryTests.cs
@@ -1,0 +1,43 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using PureDOTS.Runtime.Math;
+using Unity.Mathematics;
+
+namespace Space4X.Tests
+{
+    public sealed class PureDotsSegmentGeometryTests
+    {
+        [Test]
+        public void ResolveSegmentSphereOcclusion01_ZeroWhenLaneIsClear()
+        {
+            var occlusion = SegmentGeometry.ResolveSegmentSphereOcclusion01(
+                new float3(0f, 0f, 0f),
+                new float3(10f, 0f, 0f),
+                new float3(0f, 5f, 0f),
+                1f,
+                0f);
+
+            Assert.AreEqual(0f, occlusion, 1e-4f);
+        }
+
+        [Test]
+        public void ResolveSegmentSphereOcclusion01_IncreasesWithPathRadius()
+        {
+            var narrow = SegmentGeometry.ResolveSegmentSphereOcclusion01(
+                new float3(0f, 0f, 0f),
+                new float3(10f, 0f, 0f),
+                new float3(5f, 1f, 0f),
+                1f,
+                0f);
+            var wide = SegmentGeometry.ResolveSegmentSphereOcclusion01(
+                new float3(0f, 0f, 0f),
+                new float3(10f, 0f, 0f),
+                new float3(5f, 1f, 0f),
+                1f,
+                1f);
+
+            Assert.Greater(wide, narrow);
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlHeatCombatIntegrationTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlHeatCombatIntegrationTests.cs
@@ -230,6 +230,112 @@ namespace Space4X.Tests
 
             Assert.IsTrue(fired, "Unsafe mode should allow eventual firing despite overheat.");
         }
+
+        [Test]
+        public void WeaponSystem_UsesResolvedHeatModifiers_FromFleetcrawlRuntime()
+        {
+            using var harness = new ISystemTestHarness(fixedDelta: 0.1f);
+            var em = harness.World.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(em);
+
+            var weaponSystem = harness.World.GetOrCreateSystem<Space4XWeaponSystem>();
+            harness.Sim.AddSystemToUpdateList(weaponSystem);
+
+            var runtime = em.CreateEntity(typeof(FleetcrawlOfferRuntimeTag));
+            var rolledLimbs = em.AddBuffer<FleetcrawlRolledLimbBufferElement>(runtime);
+            var ownedItems = em.AddBuffer<FleetcrawlOwnedItem>(runtime);
+            var heatDefs = em.AddBuffer<FleetcrawlHeatModifierDefinition>(runtime);
+
+            rolledLimbs.Clear();
+            ownedItems.Add(new FleetcrawlOwnedItem
+            {
+                Value = new FleetcrawlRolledItem
+                {
+                    Archetype = FleetcrawlLootArchetype.GeneralItem,
+                    ItemId = new FixedString64Bytes("item_overheat_probe"),
+                    SetId = default,
+                    ComboTags = FleetcrawlComboTag.None
+                }
+            });
+            heatDefs.Add(new FleetcrawlHeatModifierDefinition
+            {
+                ModifierId = new FixedString64Bytes("runtime_overheat_threshold"),
+                SourceKind = FleetcrawlHeatModifierSourceKind.ItemId,
+                SourceId = new FixedString64Bytes("item_overheat_probe"),
+                OverheatThresholdOffset01 = -0.35f
+            });
+
+            var target = em.CreateEntity(typeof(LocalTransform));
+            em.SetComponentData(target, new LocalTransform
+            {
+                Position = new float3(0f, 0f, 5f),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+
+            var ship = em.CreateEntity(
+                typeof(LocalTransform),
+                typeof(Space4XEngagement),
+                typeof(SupplyStatus),
+                typeof(FleetcrawlHeatRuntimeState),
+                typeof(FleetcrawlHeatsinkState),
+                typeof(FleetcrawlHeatControlState),
+                typeof(FleetcrawlHeatOutputState));
+            em.SetComponentData(ship, new LocalTransform
+            {
+                Position = float3.zero,
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            em.SetComponentData(ship, new Space4XEngagement
+            {
+                PrimaryTarget = target,
+                Phase = EngagementPhase.Engaged
+            });
+            em.SetComponentData(ship, new SupplyStatus
+            {
+                Ammunition = 100f,
+                AmmunitionCapacity = 100f
+            });
+            em.SetComponentData(ship, new FleetcrawlHeatRuntimeState
+            {
+                CurrentHeat = 60f,
+                BaseHeatCapacity = 100f,
+                BaseDissipationPerTick = 0f,
+                BaseOverheatThreshold01 = 0.85f,
+                BaseRecoveryThreshold01 = 0.4f,
+                IsOverheated = 0
+            });
+            em.SetComponentData(ship, new FleetcrawlHeatsinkState
+            {
+                StoredHeat = 0f,
+                BaseCapacity = 0f,
+                BaseAbsorbPerTick = 0f,
+                BaseVentPerTick = 0f
+            });
+            em.SetComponentData(ship, new FleetcrawlHeatControlState
+            {
+                SafetyMode = FleetcrawlHeatSafetyMode.BalancedAutoVent,
+                HeatsinkEnabled = 0
+            });
+            em.SetComponentData(ship, new FleetcrawlHeatOutputState
+            {
+                DamageMultiplier = 1f,
+                CooldownMultiplier = 1f,
+                FireRateThrottleMultiplier = 1f,
+                EngineSpeedMultiplier = 1f,
+                ShieldRechargeMultiplier = 1f,
+                ShieldIntensityMultiplier = 1f
+            });
+            em.AddBuffer<FleetcrawlHeatActionEvent>(ship);
+            em.AddBuffer<WeaponMount>(ship);
+
+            harness.Step(1);
+
+            var output = em.GetComponentData<FleetcrawlHeatOutputState>(ship);
+            Assert.Less(output.OverheatThreshold01, 0.6f, "Runtime heat modifiers should lower threshold.");
+            Assert.AreEqual(1, output.IsOverheated, "Lower threshold should overheat this ship at 60% heat.");
+        }
     }
 }
 #endif

--- a/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlHeatContractsTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlHeatContractsTests.cs
@@ -368,6 +368,30 @@ namespace Space4X.Tests
             Assert.AreEqual(1.1f, merged.DecelerationMultiplier, 1e-4f);
             Assert.AreEqual(1.1f, merged.TurnRateMultiplier, 1e-4f);
         }
+
+        [Test]
+        public void ResolveHeatSignature01_IncreasesWithHeatsinkAndOverheat()
+        {
+            var cold = new FleetcrawlHeatOutputState
+            {
+                Heat01 = 0.2f,
+                HeatsinkStoredHeat = 0f,
+                HeatsinkCapacity = 0f,
+                IsOverheated = 0
+            };
+            var hot = new FleetcrawlHeatOutputState
+            {
+                Heat01 = 0.2f,
+                HeatsinkStoredHeat = 30f,
+                HeatsinkCapacity = 60f,
+                IsOverheated = 1
+            };
+
+            var coldSignature = FleetcrawlHeatResolver.ResolveHeatSignature01(cold);
+            var hotSignature = FleetcrawlHeatResolver.ResolveHeatSignature01(hot);
+            Assert.Greater(hotSignature, coldSignature);
+            Assert.LessOrEqual(hotSignature, 1f);
+        }
     }
 }
 #endif

--- a/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlSpecialEnergyTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlSpecialEnergyTests.cs
@@ -1,0 +1,141 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using PureDOTS.Runtime.Components;
+using Space4X.Registry;
+using Space4X.Runtime;
+using Space4X.Tests.TestHarness;
+using Space4x.Scenario;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace Space4X.Tests
+{
+    public sealed class Space4XFleetcrawlSpecialEnergyTests
+    {
+        [Test]
+        public void FleetcrawlSpecialAbility_ConsumesSpecialEnergyAndDealsDamage()
+        {
+            using var harness = new ISystemTestHarness();
+            var em = harness.World.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(em);
+
+            var flagship = em.CreateEntity(
+                typeof(LocalTransform),
+                typeof(Space4XFleetcrawlPlayerDirective),
+                typeof(PlayerFlagshipTag),
+                typeof(Space4XRunPlayerTag),
+                typeof(ShipSpecialEnergyState));
+            em.SetComponentData(flagship, new LocalTransform
+            {
+                Position = float3.zero,
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            em.SetComponentData(flagship, new Space4XFleetcrawlPlayerDirective
+            {
+                SpecialRequested = 1,
+                SpecialCooldownUntilTick = 0
+            });
+            em.SetComponentData(flagship, new ShipSpecialEnergyState
+            {
+                Current = Space4XFleetcrawlSpecialEnergyRules.SpecialAbilityCost + 5f,
+                EffectiveMax = 100f
+            });
+
+            var enemy = em.CreateEntity(
+                typeof(LocalTransform),
+                typeof(HullIntegrity),
+                typeof(ScenarioSide),
+                typeof(Space4XRunEnemyTag));
+            em.SetComponentData(enemy, new LocalTransform
+            {
+                Position = new float3(0f, 0f, 10f),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            em.SetComponentData(enemy, HullIntegrity.HeavyCarrier);
+            em.SetComponentData(enemy, new ScenarioSide { Side = 1 });
+            em.SetComponentData(enemy, new Space4XRunEnemyTag
+            {
+                RoomIndex = 0,
+                WaveIndex = 0,
+                EnemyClass = Space4XFleetcrawlEnemyClass.Normal
+            });
+
+            var system = harness.World.GetOrCreateSystem<Space4XFleetcrawlSpecialAbilitySystem>();
+            system.Update(harness.World.Unmanaged);
+
+            var energy = em.GetComponentData<ShipSpecialEnergyState>(flagship);
+            var directive = em.GetComponentData<Space4XFleetcrawlPlayerDirective>(flagship);
+            var damage = em.GetBuffer<DamageEvent>(enemy);
+
+            Assert.AreEqual(5f, energy.Current, 1e-4f);
+            Assert.AreEqual(0, directive.SpecialRequested);
+            Assert.Greater(damage.Length, 0, "Special ability should emit damage events when energy is available.");
+        }
+
+        [Test]
+        public void FleetcrawlSpecialAbility_DeniesWhenEnergyInsufficient()
+        {
+            using var harness = new ISystemTestHarness();
+            var em = harness.World.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(em);
+
+            var flagship = em.CreateEntity(
+                typeof(LocalTransform),
+                typeof(Space4XFleetcrawlPlayerDirective),
+                typeof(PlayerFlagshipTag),
+                typeof(Space4XRunPlayerTag),
+                typeof(ShipSpecialEnergyState));
+            em.SetComponentData(flagship, new LocalTransform
+            {
+                Position = float3.zero,
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            em.SetComponentData(flagship, new Space4XFleetcrawlPlayerDirective
+            {
+                SpecialRequested = 1,
+                SpecialCooldownUntilTick = 0
+            });
+            em.SetComponentData(flagship, new ShipSpecialEnergyState
+            {
+                Current = 0f,
+                EffectiveMax = 100f
+            });
+
+            var enemy = em.CreateEntity(
+                typeof(LocalTransform),
+                typeof(HullIntegrity),
+                typeof(ScenarioSide),
+                typeof(Space4XRunEnemyTag));
+            em.SetComponentData(enemy, new LocalTransform
+            {
+                Position = new float3(0f, 0f, 10f),
+                Rotation = quaternion.identity,
+                Scale = 1f
+            });
+            em.SetComponentData(enemy, HullIntegrity.HeavyCarrier);
+            em.SetComponentData(enemy, new ScenarioSide { Side = 1 });
+            em.SetComponentData(enemy, new Space4XRunEnemyTag
+            {
+                RoomIndex = 0,
+                WaveIndex = 0,
+                EnemyClass = Space4XFleetcrawlEnemyClass.Normal
+            });
+
+            var system = harness.World.GetOrCreateSystem<Space4XFleetcrawlSpecialAbilitySystem>();
+            system.Update(harness.World.Unmanaged);
+
+            var energy = em.GetComponentData<ShipSpecialEnergyState>(flagship);
+            var directive = em.GetComponentData<Space4XFleetcrawlPlayerDirective>(flagship);
+            var hasDamageBuffer = em.HasBuffer<DamageEvent>(enemy);
+
+            Assert.AreEqual(0, directive.SpecialRequested);
+            Assert.AreEqual(1, energy.FailedSpendAttempts);
+            Assert.IsFalse(hasDamageBuffer, "Special ability should not fire without sufficient energy.");
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlSpecialEnergyTests.cs.meta
+++ b/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlSpecialEnergyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aed19ad325304e89af77f62292bc3baf

--- a/Assets/Scripts/Space4x/Tests/Space4XSpecialEnergySystemTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XSpecialEnergySystemTests.cs
@@ -1,0 +1,172 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using Space4X.Registry;
+using Space4X.Runtime;
+using Space4X.Systems.Power;
+using Space4X.Tests.TestHarness;
+using Unity.Entities;
+
+namespace Space4X.Tests
+{
+    public sealed class Space4XSpecialEnergySystemTests
+    {
+        [Test]
+        public void SpecialEnergySystem_RegenScalesWithReactor()
+        {
+            using var harness = new ISystemTestHarness();
+            var em = harness.World.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(em);
+
+            var timeEntity = em.CreateEntityQuery(ComponentType.ReadWrite<PureDOTS.Runtime.Components.TimeState>()).GetSingletonEntity();
+            var time = em.GetComponentData<PureDOTS.Runtime.Components.TimeState>(timeEntity);
+            time.FixedDeltaTime = 0.5f;
+            em.SetComponentData(timeEntity, time);
+
+            var ship = em.CreateEntity(
+                typeof(ShipReactorSpec),
+                typeof(ShipSpecialEnergyConfig),
+                typeof(ShipSpecialEnergyState));
+            em.SetComponentData(ship, new ShipReactorSpec
+            {
+                OutputMW = 1000f,
+                Efficiency = 0.8f
+            });
+            em.SetComponentData(ship, new ShipSpecialEnergyConfig
+            {
+                BaseMax = 50f,
+                BaseRegenPerSecond = 2f,
+                ReactorOutputToMax = 0.01f,
+                ReactorOutputToRegen = 0.002f,
+                ReactorEfficiencyRegenMultiplier = 1f,
+                RestartRegenPenaltyMultiplier = 0.2f,
+                ActivationCostMultiplier = 1f
+            });
+            em.SetComponentData(ship, new ShipSpecialEnergyState
+            {
+                Current = 10f,
+                EffectiveMax = 0f,
+                EffectiveRegenPerSecond = 0f
+            });
+            em.AddBuffer<ShipSpecialEnergyPassiveModifier>(ship);
+            em.AddBuffer<ShipSpecialEnergySpendRequest>(ship);
+
+            var system = harness.World.GetOrCreateSystem<Space4XShipSpecialEnergySystem>();
+            system.Update(harness.World.Unmanaged);
+
+            var energy = em.GetComponentData<ShipSpecialEnergyState>(ship);
+            Assert.AreEqual(60f, energy.EffectiveMax, 1e-4f);
+            Assert.AreEqual(3.2f, energy.EffectiveRegenPerSecond, 1e-4f);
+            Assert.AreEqual(11.6f, energy.Current, 1e-4f);
+        }
+
+        [Test]
+        public void SpecialEnergySystem_PassiveCapReduction_ClampsCurrentAndTracksFailedSpends()
+        {
+            using var harness = new ISystemTestHarness();
+            var em = harness.World.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(em);
+
+            var ship = em.CreateEntity(
+                typeof(ShipReactorSpec),
+                typeof(ShipSpecialEnergyConfig),
+                typeof(ShipSpecialEnergyState));
+            em.SetComponentData(ship, new ShipReactorSpec
+            {
+                OutputMW = 0f,
+                Efficiency = 1f
+            });
+            em.SetComponentData(ship, new ShipSpecialEnergyConfig
+            {
+                BaseMax = 80f,
+                BaseRegenPerSecond = 0f,
+                ReactorOutputToMax = 0f,
+                ReactorOutputToRegen = 0f,
+                ReactorEfficiencyRegenMultiplier = 1f,
+                RestartRegenPenaltyMultiplier = 0.2f,
+                ActivationCostMultiplier = 1f
+            });
+            em.SetComponentData(ship, new ShipSpecialEnergyState
+            {
+                Current = 90f,
+                EffectiveMax = 0f,
+                EffectiveRegenPerSecond = 0f
+            });
+
+            var modifiers = em.AddBuffer<ShipSpecialEnergyPassiveModifier>(ship);
+            modifiers.Add(new ShipSpecialEnergyPassiveModifier
+            {
+                AdditiveMax = -30f,
+                MultiplicativeMax = 1f,
+                AdditiveRegenPerSecond = 0f,
+                MultiplicativeRegen = 1f
+            });
+
+            var spends = em.AddBuffer<ShipSpecialEnergySpendRequest>(ship);
+            spends.Add(new ShipSpecialEnergySpendRequest
+            {
+                Amount = 60f
+            });
+
+            var system = harness.World.GetOrCreateSystem<Space4XShipSpecialEnergySystem>();
+            system.Update(harness.World.Unmanaged);
+
+            var energy = em.GetComponentData<ShipSpecialEnergyState>(ship);
+            Assert.AreEqual(50f, energy.EffectiveMax, 1e-4f);
+            Assert.AreEqual(50f, energy.Current, 1e-4f);
+            Assert.AreEqual(1, energy.FailedSpendAttempts);
+        }
+
+        [Test]
+        public void FocusAbilitySystem_ConsumesSpecialEnergyWhenPresent()
+        {
+            using var harness = new ISystemTestHarness();
+            var em = harness.World.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(em);
+
+            var actor = em.CreateEntity(
+                typeof(Space4XEntityFocus),
+                typeof(OfficerFocusProfile),
+                typeof(ShipSpecialEnergyState));
+            em.SetComponentData(actor, Space4XEntityFocus.Default(100f));
+            em.SetComponentData(actor, OfficerFocusProfile.Captain());
+            em.SetComponentData(actor, new ShipSpecialEnergyState
+            {
+                Current = 1f,
+                EffectiveMax = 20f,
+                EffectiveRegenPerSecond = 0f
+            });
+            em.AddBuffer<Space4XActiveFocusAbility>(actor);
+
+            em.AddComponentData(actor, new FocusAbilityRequest
+            {
+                RequestedAbility = (ushort)Space4XFocusAbilityType.OfficerSupport
+            });
+
+            var system = harness.World.GetOrCreateSystem<Space4XFocusAbilitySystem>();
+            system.Update(harness.World.Unmanaged);
+
+            var abilitiesAfterFail = em.GetBuffer<Space4XActiveFocusAbility>(actor);
+            var energyAfterFail = em.GetComponentData<ShipSpecialEnergyState>(actor);
+            Assert.AreEqual(0, abilitiesAfterFail.Length, "Ability should not activate when special energy is insufficient.");
+            Assert.AreEqual(1, energyAfterFail.FailedSpendAttempts);
+            Assert.IsFalse(em.HasComponent<FocusAbilityRequest>(actor), "Failed request should be consumed.");
+
+            var requiredCost = Space4XFocusAbilityDefinitions.GetSpecialEnergyActivationCost(Space4XFocusAbilityType.OfficerSupport);
+            energyAfterFail.Current = requiredCost + 1f;
+            em.SetComponentData(actor, energyAfterFail);
+            em.AddComponentData(actor, new FocusAbilityRequest
+            {
+                RequestedAbility = (ushort)Space4XFocusAbilityType.OfficerSupport
+            });
+
+            system.Update(harness.World.Unmanaged);
+
+            var abilitiesAfterSuccess = em.GetBuffer<Space4XActiveFocusAbility>(actor);
+            var energyAfterSuccess = em.GetComponentData<ShipSpecialEnergyState>(actor);
+            Assert.AreEqual(1, abilitiesAfterSuccess.Length, "Ability should activate when special energy is available.");
+            Assert.AreEqual(1f, energyAfterSuccess.Current, 1e-3f);
+            Assert.IsFalse(em.HasComponent<FocusAbilityRequest>(actor), "Successful request should be consumed.");
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Space4x/Tests/Space4XSpecialEnergySystemTests.cs.meta
+++ b/Assets/Scripts/Space4x/Tests/Space4XSpecialEnergySystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c34be9c788e6464990a16aaaec89e6e1

--- a/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs
@@ -78,6 +78,26 @@ namespace Space4X.Tests
             Assert.Greater(torpedoHot, missileHot);
             Assert.AreEqual(1f, kineticHot, 1e-4f);
         }
+
+        [Test]
+        public void HazardOcclusion_BeamsResistAndBlastAssists()
+        {
+            var laserProfile = Space4XWeaponFamilyNuance.ResolveProfile(
+                Space4XWeaponFamilyNuance.ResolveArchetype(Space4XWeapon.Laser(WeaponSize.Medium)));
+            var kineticProfile = Space4XWeaponFamilyNuance.ResolveProfile(
+                Space4XWeaponFamilyNuance.ResolveArchetype(Space4XWeapon.Kinetic(WeaponSize.Medium)));
+            var torpedoProfile = Space4XWeaponFamilyNuance.ResolveProfile(
+                Space4XWeaponFamilyNuance.ResolveArchetype(Space4XWeapon.Torpedo(WeaponSize.Medium)));
+
+            var beamOccluded = Space4XWeaponFamilyNuance.ResolveHazardOcclusionHitChanceMultiplier(1f, 0f, laserProfile);
+            var kineticOccluded = Space4XWeaponFamilyNuance.ResolveHazardOcclusionHitChanceMultiplier(1f, 0f, kineticProfile);
+            var torpedoNoBlast = Space4XWeaponFamilyNuance.ResolveHazardOcclusionHitChanceMultiplier(1f, 0f, torpedoProfile);
+            var torpedoBlast = Space4XWeaponFamilyNuance.ResolveHazardOcclusionHitChanceMultiplier(1f, 12f, torpedoProfile);
+
+            Assert.Greater(beamOccluded, kineticOccluded);
+            Assert.Greater(torpedoBlast, torpedoNoBlast);
+            Assert.LessOrEqual(beamOccluded, 1f);
+        }
     }
 }
 #endif

--- a/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs
@@ -55,6 +55,29 @@ namespace Space4X.Tests
 
             Assert.AreEqual(0, ammo);
         }
+
+        [Test]
+        public void GuidedWeapons_HeatSeekBonusScalesWithTargetHeat()
+        {
+            var missile = Space4XWeapon.Missile(WeaponSize.Medium);
+            var missileProfile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(missile));
+
+            var torpedo = Space4XWeapon.Torpedo(WeaponSize.Medium);
+            var torpedoProfile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(torpedo));
+
+            var kinetic = Space4XWeapon.Kinetic(WeaponSize.Medium);
+            var kineticProfile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(kinetic));
+
+            var missileCold = Space4XWeaponFamilyNuance.ResolveHeatSeekHitChanceMultiplier(0f, missileProfile);
+            var missileHot = Space4XWeaponFamilyNuance.ResolveHeatSeekHitChanceMultiplier(1f, missileProfile);
+            var torpedoHot = Space4XWeaponFamilyNuance.ResolveHeatSeekHitChanceMultiplier(1f, torpedoProfile);
+            var kineticHot = Space4XWeaponFamilyNuance.ResolveHeatSeekHitChanceMultiplier(1f, kineticProfile);
+
+            Assert.AreEqual(1f, missileCold, 1e-4f);
+            Assert.Greater(missileHot, missileCold);
+            Assert.Greater(torpedoHot, missileHot);
+            Assert.AreEqual(1f, kineticHot, 1e-4f);
+        }
     }
 }
 #endif

--- a/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs
@@ -1,0 +1,60 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using Space4X.Registry;
+
+namespace Space4X.Tests
+{
+    public sealed class Space4XWeaponFamilyNuanceTests
+    {
+        [Test]
+        public void PlasmaProfile_UsesHeatBiasAndDistanceDissipation()
+        {
+            var weapon = new Space4XWeapon
+            {
+                Type = WeaponType.Plasma,
+                Size = WeaponSize.Medium,
+                OptimalRange = 300f,
+                MaxRange = 800f
+            };
+
+            var profile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(weapon));
+            var heat = Space4XWeaponFamilyNuance.ResolveHeatPerShot(1f, profile);
+            var near = Space4XWeaponFamilyNuance.ResolveDistanceDamageMultiplier(120f, weapon.OptimalRange, weapon.MaxRange, profile);
+            var far = Space4XWeaponFamilyNuance.ResolveDistanceDamageMultiplier(760f, weapon.OptimalRange, weapon.MaxRange, profile);
+
+            Assert.Greater(heat, 1f);
+            Assert.Greater(near, far);
+        }
+
+        [Test]
+        public void GuidedWeapons_SpendMoreAmmoAndLoseHitChance()
+        {
+            var missile = Space4XWeapon.Missile(WeaponSize.Medium);
+            var missileProfile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(missile));
+
+            var torpedo = Space4XWeapon.Torpedo(WeaponSize.Medium);
+            var torpedoProfile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(torpedo));
+
+            var missileAmmo = Space4XWeaponFamilyNuance.ResolveAmmoPerShot(missile.AmmoPerShot, missileProfile);
+            var torpedoAmmo = Space4XWeaponFamilyNuance.ResolveAmmoPerShot(torpedo.AmmoPerShot, torpedoProfile);
+            var missileHitMul = Space4XWeaponFamilyNuance.ResolveHitChanceMultiplier(missileProfile);
+            var torpedoHitMul = Space4XWeaponFamilyNuance.ResolveHitChanceMultiplier(torpedoProfile);
+
+            Assert.GreaterOrEqual(missileAmmo, 2);
+            Assert.GreaterOrEqual(torpedoAmmo, missileAmmo);
+            Assert.Less(missileHitMul, 1f);
+            Assert.Less(torpedoHitMul, missileHitMul);
+        }
+
+        [Test]
+        public void EnergyWeapons_DoNotConsumeAmmo()
+        {
+            var laser = Space4XWeapon.Laser(WeaponSize.Small);
+            var profile = Space4XWeaponFamilyNuance.ResolveProfile(Space4XWeaponFamilyNuance.ResolveArchetype(laser));
+            var ammo = Space4XWeaponFamilyNuance.ResolveAmmoPerShot(3, profile);
+
+            Assert.AreEqual(0, ammo);
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs.meta
+++ b/Assets/Scripts/Space4x/Tests/Space4XWeaponFamilyNuanceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65fe3932eb8c4e0d9bda91dd4dd61e95

--- a/Assets/Scripts/Space4x/UI/Space4XControlModeState.cs
+++ b/Assets/Scripts/Space4x/UI/Space4XControlModeState.cs
@@ -6,7 +6,8 @@ namespace Space4X.UI
     {
         CursorOrient = 0,
         CruiseLook = 1,
-        Rts = 2
+        Rts = 2,
+        DivineHand = 3
     }
 
     public static class Space4XControlModeState
@@ -18,6 +19,7 @@ namespace Space4X.UI
         private static bool _cursorOrientVariantEnabled;
         private static bool _cruiseLookVariantEnabled;
         private static bool _rtsVariantEnabled;
+        private static bool _divineHandVariantEnabled;
 
         public static void SetMode(Space4XControlMode mode)
         {
@@ -47,6 +49,7 @@ namespace Space4X.UI
                 Space4XControlMode.CursorOrient => _cursorOrientVariantEnabled,
                 Space4XControlMode.CruiseLook => _cruiseLookVariantEnabled,
                 Space4XControlMode.Rts => _rtsVariantEnabled,
+                Space4XControlMode.DivineHand => _divineHandVariantEnabled,
                 _ => false
             };
         }
@@ -67,6 +70,10 @@ namespace Space4X.UI
                     if (_rtsVariantEnabled == enabled) return;
                     _rtsVariantEnabled = enabled;
                     break;
+                case Space4XControlMode.DivineHand:
+                    if (_divineHandVariantEnabled == enabled) return;
+                    _divineHandVariantEnabled = enabled;
+                    break;
                 default:
                     return;
             }
@@ -84,6 +91,7 @@ namespace Space4X.UI
             SetVariantEnabled(Space4XControlMode.CursorOrient, false);
             SetVariantEnabled(Space4XControlMode.CruiseLook, false);
             SetVariantEnabled(Space4XControlMode.Rts, false);
+            SetVariantEnabled(Space4XControlMode.DivineHand, false);
             SetMode(Space4XControlMode.CursorOrient);
         }
     }

--- a/Assets/Scripts/Space4x/UI/Space4XPlayerFlagshipController.cs
+++ b/Assets/Scripts/Space4x/UI/Space4XPlayerFlagshipController.cs
@@ -65,6 +65,7 @@ namespace Space4X.UI
         [SerializeField] private Key cursorModeHotkey = Key.Digit1;
         [SerializeField] private Key cruiseModeHotkey = Key.Digit2;
         [SerializeField] private Key rtsModeHotkey = Key.Digit3;
+        [SerializeField] private Key divineHandModeHotkey = Key.Digit4;
 
         [Header("Attitude")]
         [SerializeField] private float rollSpeedDegrees = 75f;
@@ -217,7 +218,8 @@ namespace Space4X.UI
             if (!EnsureClaimedFlagship())
                 return;
 
-            if (Space4XControlModeState.CurrentMode == Space4XControlMode.Rts)
+            if (Space4XControlModeState.CurrentMode == Space4XControlMode.Rts ||
+                Space4XControlModeState.CurrentMode == Space4XControlMode.DivineHand)
             {
                 PrepareFlagshipForRtsOrders();
                 SuppressFlagshipMovement();
@@ -1000,6 +1002,10 @@ namespace Space4X.UI
             {
                 Space4XControlModeState.SetModeOrToggleVariant(Space4XControlMode.Rts);
             }
+            else if (divineHandModeHotkey != Key.None && keyboard[divineHandModeHotkey].wasPressedThisFrame)
+            {
+                Space4XControlModeState.SetModeOrToggleVariant(Space4XControlMode.DivineHand);
+            }
         }
 
         private bool ShouldHandleModeHotkeys()
@@ -1009,7 +1015,7 @@ namespace Space4X.UI
                 _followPlayerVessel = GetComponent<Space4XFollowPlayerVessel>();
             }
 
-            // Follow camera owns mode hotkeys when present to avoid duplicate 1/2/3 processing.
+            // Follow camera owns mode hotkeys when present to avoid duplicate 1/2/3/4 processing.
             return _followPlayerVessel == null || !_followPlayerVessel.isActiveAndEnabled;
         }
 

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/ResourcePoolMath.cs
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/ResourcePoolMath.cs
@@ -1,0 +1,53 @@
+using Unity.Mathematics;
+
+namespace PureDOTS.Runtime.Math
+{
+    /// <summary>
+    /// Shared deterministic math helpers for rechargeable resource pools.
+    /// </summary>
+    public static class ResourcePoolMath
+    {
+        public static float ResolveModifiedMax(float baseMax, float additiveMax, float multiplicativeMax)
+        {
+            var safeBase = math.max(0f, baseMax);
+            var safeMult = math.max(0.01f, multiplicativeMax);
+            return math.max(0f, (safeBase + additiveMax) * safeMult);
+        }
+
+        public static float ResolveModifiedRate(float baseRate, float additiveRate, float multiplicativeRate)
+        {
+            var safeBase = math.max(0f, baseRate);
+            var safeMult = math.max(0f, multiplicativeRate);
+            return math.max(0f, (safeBase + additiveRate) * safeMult);
+        }
+
+        public static float ClampCurrent(float current, float maxValue)
+        {
+            return math.clamp(current, 0f, math.max(0f, maxValue));
+        }
+
+        public static float Regen(float current, float maxValue, float regenPerSecond, float deltaSeconds)
+        {
+            var maxClamped = math.max(0f, maxValue);
+            var regen = math.max(0f, regenPerSecond) * math.max(0f, deltaSeconds);
+            return math.min(maxClamped, math.max(0f, current) + regen);
+        }
+
+        public static bool CanSpend(float current, float amount)
+        {
+            return math.max(0f, current) >= math.max(0f, amount);
+        }
+
+        public static bool TrySpend(ref float current, float amount)
+        {
+            var spend = math.max(0f, amount);
+            if (!CanSpend(current, spend))
+            {
+                return false;
+            }
+
+            current = math.max(0f, current - spend);
+            return true;
+        }
+    }
+}

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/ResourcePoolMath.cs
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/ResourcePoolMath.cs
@@ -1,4 +1,5 @@
 using Unity.Mathematics;
+using PureDOTS.Runtime.Resources;
 
 namespace PureDOTS.Runtime.Math
 {
@@ -7,6 +8,14 @@ namespace PureDOTS.Runtime.Math
     /// </summary>
     public static class ResourcePoolMath
     {
+        public static void AccumulateModifier(ref ResourcePoolModifier accumulator, in ResourcePoolModifier modifier)
+        {
+            accumulator.AdditiveMax += modifier.AdditiveMax;
+            accumulator.MultiplicativeMax *= modifier.MultiplicativeMax <= 0f ? 1f : modifier.MultiplicativeMax;
+            accumulator.AdditiveRegenPerSecond += modifier.AdditiveRegenPerSecond;
+            accumulator.MultiplicativeRegen *= modifier.MultiplicativeRegen <= 0f ? 1f : modifier.MultiplicativeRegen;
+        }
+
         public static float ResolveModifiedMax(float baseMax, float additiveMax, float multiplicativeMax)
         {
             var safeBase = math.max(0f, baseMax);
@@ -48,6 +57,11 @@ namespace PureDOTS.Runtime.Math
 
             current = math.max(0f, current - spend);
             return true;
+        }
+
+        public static float ResolveSpendCost(float amount, float costMultiplier)
+        {
+            return math.max(0f, amount) * math.max(0f, costMultiplier);
         }
     }
 }

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/ResourcePoolMath.cs.meta
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/ResourcePoolMath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 73041500082f43ccb734701b9d79ef59

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/SegmentGeometry.cs
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Math/SegmentGeometry.cs
@@ -1,0 +1,46 @@
+using Unity.Mathematics;
+
+namespace PureDOTS.Runtime.Math
+{
+    public static class SegmentGeometry
+    {
+        public static float DistancePointToSegmentSq(float3 point, float3 start, float3 end, out float t)
+        {
+            var segment = end - start;
+            var lengthSq = math.lengthsq(segment);
+            if (lengthSq <= 1e-8f)
+            {
+                t = 0f;
+                return math.lengthsq(point - start);
+            }
+
+            t = math.saturate(math.dot(point - start, segment) / lengthSq);
+            var closest = start + segment * t;
+            return math.lengthsq(point - closest);
+        }
+
+        public static float ResolveSegmentSphereOcclusion01(
+            float3 start,
+            float3 end,
+            float3 sphereCenter,
+            float sphereRadius,
+            float pathRadius = 0f)
+        {
+            var effectiveRadius = math.max(0f, sphereRadius) + math.max(0f, pathRadius);
+            if (effectiveRadius <= 1e-5f)
+            {
+                return 0f;
+            }
+
+            var distanceSq = DistancePointToSegmentSq(sphereCenter, start, end, out _);
+            var radiusSq = effectiveRadius * effectiveRadius;
+            if (distanceSq >= radiusSq)
+            {
+                return 0f;
+            }
+
+            var distance = math.sqrt(distanceSq);
+            return math.saturate(1f - distance / effectiveRadius);
+        }
+    }
+}

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Progression/ProgressionMath.cs
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Progression/ProgressionMath.cs
@@ -1,0 +1,79 @@
+using Unity.Mathematics;
+
+namespace PureDOTS.Runtime.Progression
+{
+    /// <summary>
+    /// Shared deterministic helpers for skill/proficiency accumulation and milestone checks.
+    /// </summary>
+    public static class ProgressionMath
+    {
+        public static float ResolveLearningMultiplier(float normalizedStat01, float minMultiplier, float maxMultiplier)
+        {
+            var stat01 = math.saturate(normalizedStat01);
+            var min = math.max(0f, minMultiplier);
+            var max = math.max(min, maxMultiplier);
+            return math.lerp(min, max, stat01);
+        }
+
+        public static float ResolveSkill01FromPractice(
+            float practiceSeconds,
+            float secondsToMastery,
+            float wisdom01,
+            float aptitude01,
+            float wisdomMultiplierMin,
+            float wisdomMultiplierMax,
+            float aptitudeMultiplierMin,
+            float aptitudeMultiplierMax)
+        {
+            var safePractice = math.max(0f, practiceSeconds);
+            var wisdomFactor = ResolveLearningMultiplier(wisdom01, wisdomMultiplierMin, wisdomMultiplierMax);
+            var aptitudeFactor = ResolveLearningMultiplier(aptitude01, aptitudeMultiplierMin, aptitudeMultiplierMax);
+            var effectiveSeconds = safePractice * wisdomFactor * aptitudeFactor;
+            return ResolveSkill01(effectiveSeconds, secondsToMastery);
+        }
+
+        public static float ResolveSkill01(float effectivePracticeSeconds, float secondsToMastery)
+        {
+            var safePractice = math.max(0f, effectivePracticeSeconds);
+            var mastery = math.max(1e-5f, secondsToMastery);
+            return math.saturate(safePractice / mastery);
+        }
+
+        public static void AccumulatePositive(ref float accumulator, float delta)
+        {
+            if (delta <= 0f)
+            {
+                return;
+            }
+
+            accumulator += delta;
+        }
+
+        public static float ResolveLinearMilestoneThreshold(float baseThreshold, float perMilestoneStep, int milestoneIndex)
+        {
+            var index = math.max(0, milestoneIndex);
+            var baseValue = math.max(0f, baseThreshold);
+            var step = math.max(0f, perMilestoneStep);
+            return baseValue + step * index;
+        }
+
+        public static int ResolveLinearMilestoneCount(float totalValue, float baseThreshold, float perMilestoneStep, int maxMilestones = 32)
+        {
+            var value = math.max(0f, totalValue);
+            var cap = math.max(0, maxMilestones);
+            var count = 0;
+            for (var i = 0; i < cap; i++)
+            {
+                var threshold = ResolveLinearMilestoneThreshold(baseThreshold, perMilestoneStep, i);
+                if (value + 1e-5f < threshold)
+                {
+                    break;
+                }
+
+                count++;
+            }
+
+            return count;
+        }
+    }
+}

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Resources.meta
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77e8c8ce0ee64bd9b1dfdbbaf73bb75e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Resources/ResourcePoolPrimitives.cs
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Resources/ResourcePoolPrimitives.cs
@@ -1,0 +1,64 @@
+using Unity.Mathematics;
+
+namespace PureDOTS.Runtime.Resources
+{
+    /// <summary>
+    /// Game-agnostic configuration for a rechargeable resource pool.
+    /// </summary>
+    public struct ResourcePoolConfig
+    {
+        public float BaseMax;
+        public float BaseRegenPerSecond;
+        public float SpendCostMultiplier;
+
+        public static ResourcePoolConfig Default => new ResourcePoolConfig
+        {
+            BaseMax = 100f,
+            BaseRegenPerSecond = 0f,
+            SpendCostMultiplier = 1f
+        };
+    }
+
+    /// <summary>
+    /// Runtime state for a rechargeable resource pool.
+    /// </summary>
+    public struct ResourcePoolState
+    {
+        public float Current;
+        public float EffectiveMax;
+        public float EffectiveRegenPerSecond;
+        public float LastSpent;
+        public uint LastSpendTick;
+        public ushort FailedSpendAttempts;
+        public uint LastUpdatedTick;
+
+        public float Ratio => EffectiveMax > 0f ? math.saturate(Current / EffectiveMax) : 0f;
+    }
+
+    /// <summary>
+    /// Generic additive/multiplicative modifiers for pool cap and regen.
+    /// </summary>
+    public struct ResourcePoolModifier
+    {
+        public float AdditiveMax;
+        public float MultiplicativeMax;
+        public float AdditiveRegenPerSecond;
+        public float MultiplicativeRegen;
+
+        public static ResourcePoolModifier Identity => new ResourcePoolModifier
+        {
+            AdditiveMax = 0f,
+            MultiplicativeMax = 1f,
+            AdditiveRegenPerSecond = 0f,
+            MultiplicativeRegen = 1f
+        };
+    }
+
+    /// <summary>
+    /// Generic spend request payload for resource pools.
+    /// </summary>
+    public struct ResourcePoolSpendRequest
+    {
+        public float Amount;
+    }
+}

--- a/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Resources/ResourcePoolPrimitives.cs.meta
+++ b/PureDOTS/Packages/com.moni.puredots/Runtime/Runtime/Resources/ResourcePoolPrimitives.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26e46403fa81472a883403a81729319e


### PR DESCRIPTION
## Summary\n- add Space4XWeaponFamilyNuance profiles for energy/kinetic/guided/plasma families\n- wire weapon-family modifiers into firing: heat-per-shot scaling and ordnance-per-shot scaling\n- wire family effects into hit resolution: guided interception pressure and range-based damage dissipation\n- add tests covering plasma dissipation, guided ordnance scaling, and energy ammo-free behavior\n\n## Notes\n- tuned to coexist with existing module cooling/heatsink and Fleetcrawl heat systems\n- companion PureDOTS reusable profile PR is opened separately