### PR TITLE
Fix compile ambiguities for flagship progression and captain stats

### DIFF
--- a/Assets/Scripts/Space4x/Adapters/Physics/Space4xPhysicsAdapter.cs
+++ b/Assets/Scripts/Space4x/Adapters/Physics/Space4xPhysicsAdapter.cs
@@ -151,12 +151,13 @@ namespace Space4X.Adapters.Physics
                     var sourceMass = ResolveMass(evt.OtherEntity, ref _physicsMassLookup, ref _interactionConfigLookup);
                     var targetMass = ResolveMass(entity, ref _physicsMassLookup, ref _interactionConfigLookup);
 
-                    var kinematics = CollisionDamage.ComputeImpactKinematics(
+                    CollisionDamage.ComputeImpactKinematics(
                         sourceVelocity,
                         sourceMass,
                         targetVelocity,
                         targetMass,
-                        evt.ContactNormal);
+                        evt.ContactNormal,
+                        out var kinematics);
 
                     var effectiveImpulse = CollisionDamage.ResolveEffectiveImpulse(evt.Impulse, in kinematics);
 

--- a/Assets/Scripts/Space4x/Diagnostics/Space4XPresentationBootstrapOverride.cs
+++ b/Assets/Scripts/Space4x/Diagnostics/Space4XPresentationBootstrapOverride.cs
@@ -15,7 +15,7 @@ namespace Space4X.Diagnostics
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void EmitLaptopValidationProbe()
         {
-            Debug.Log($"{LaptopValidationProbeMarker} checkout reached editor domain reload.");
+            UnityEngine.Debug.Log($"{LaptopValidationProbeMarker} checkout reached editor domain reload.");
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]

--- a/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
+++ b/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
@@ -524,7 +524,7 @@ namespace Space4X.Progression
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"[Space4XPersistentProgression] Failed to load progression file: {ex.Message}");
+                UnityEngine.Debug.LogWarning($"[Space4XPersistentProgression] Failed to load progression file: {ex.Message}");
             }
 
             return state;
@@ -583,7 +583,7 @@ namespace Space4X.Progression
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"[Space4XPersistentProgression] Failed to save progression file: {ex.Message}");
+                UnityEngine.Debug.LogWarning($"[Space4XPersistentProgression] Failed to save progression file: {ex.Message}");
                 return false;
             }
         }

--- a/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
+++ b/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
@@ -199,7 +199,7 @@ namespace Space4X.Progression
             var em = state.EntityManager;
             var ecb = new EntityCommandBuffer(Allocator.Temp);
             foreach (var (movement, entity) in SystemAPI.Query<RefRO<VesselMovement>>()
-                         .WithAll<PlayerFlagshipTag>()
+                         .WithAll<Space4x.Scenario.PlayerFlagshipTag>()
                          .WithNone<Space4XThrustProgressionTracker>()
                          .WithEntityAccess())
             {
@@ -220,7 +220,7 @@ namespace Space4X.Progression
 
             var progressionState = progression.ValueRO;
             foreach (var (movement, tracker) in SystemAPI.Query<RefRO<VesselMovement>, RefRW<Space4XThrustProgressionTracker>>()
-                         .WithAll<PlayerFlagshipTag>())
+                         .WithAll<Space4x.Scenario.PlayerFlagshipTag>())
             {
                 var speed = math.max(0f, movement.ValueRO.CurrentSpeed);
                 var previous = math.max(0f, tracker.ValueRO.LastSpeed);
@@ -269,7 +269,7 @@ namespace Space4X.Progression
             var em = state.EntityManager;
             var ecb = new EntityCommandBuffer(Allocator.Temp);
             foreach (var (_, entity) in SystemAPI.Query<DynamicBuffer<WeaponMount>>()
-                         .WithAll<PlayerFlagshipTag>()
+                         .WithAll<Space4x.Scenario.PlayerFlagshipTag>()
                          .WithNone<Space4XPersistentWeaponMountTracker>()
                          .WithEntityAccess())
             {
@@ -279,7 +279,7 @@ namespace Space4X.Progression
             ecb.Playback(em);
             ecb.Dispose();
 
-            foreach (var (mounts, entity) in SystemAPI.Query<DynamicBuffer<WeaponMount>>().WithAll<PlayerFlagshipTag>().WithEntityAccess())
+            foreach (var (mounts, entity) in SystemAPI.Query<DynamicBuffer<WeaponMount>>().WithAll<Space4x.Scenario.PlayerFlagshipTag>().WithEntityAccess())
             {
                 var trackers = em.GetBuffer<Space4XPersistentWeaponMountTracker>(entity);
 

--- a/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
+++ b/Assets/Scripts/Space4x/Progression/Space4XPersistentProgressionSystems.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using PureDOTS.Runtime.Components;
 using Space4X.Registry;
+using Space4X.Runtime;
 using Space4x.Scenario;
 using Unity.Collections;
 using Unity.Entities;

--- a/Assets/Scripts/Space4x/Registry/Space4XFocusSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XFocusSystem.cs
@@ -159,7 +159,8 @@ namespace Space4X.Registry
                 {
                     var specialEnergy = _specialEnergyLookup[entity];
                     var specialEnergyCost = Space4XFocusAbilityDefinitions.GetSpecialEnergyActivationCost(abilityType);
-                    if (!ResourcePoolMath.TrySpend(ref specialEnergy.Current, specialEnergyCost))
+                    var currentSpecialEnergy = specialEnergy.Current;
+                    if (!ResourcePoolMath.TrySpend(ref currentSpecialEnergy, specialEnergyCost))
                     {
                         specialEnergy.FailedSpendAttempts =
                             (ushort)math.min((int)ushort.MaxValue, specialEnergy.FailedSpendAttempts + 1);
@@ -168,6 +169,7 @@ namespace Space4X.Registry
                         continue;
                     }
 
+                    specialEnergy.Current = currentSpecialEnergy;
                     specialEnergy.LastSpent = specialEnergyCost;
                     specialEnergy.LastSpendTick = currentTick;
                     _specialEnergyLookup[entity] = specialEnergy;

--- a/Assets/Scripts/Space4x/Registry/Space4XSpecialEnergyTelemetrySystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XSpecialEnergyTelemetrySystem.cs
@@ -1,17 +1,14 @@
 using PureDOTS.Runtime.Telemetry;
 using Space4X.Runtime;
-using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 
 namespace Space4X.Registry
 {
-    [BurstCompile]
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct Space4XSpecialEnergyTelemetrySystem : ISystem
     {
-        [BurstCompile]
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<TelemetryStream>();
@@ -19,7 +16,6 @@ namespace Space4X.Registry
             state.RequireForUpdate<ShipSpecialEnergyState>();
         }
 
-        [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
             if (!SystemAPI.TryGetSingleton<TelemetryExportConfig>(out var config) ||

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlMetaProficiencySystems.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlMetaProficiencySystems.cs
@@ -219,7 +219,7 @@ namespace Space4x.Scenario
             }
         }
 
-        private static void EnsureDamageEventCursors(ref SystemState state)
+        private void EnsureDamageEventCursors(ref SystemState state)
         {
             var ecb = new EntityCommandBuffer(Allocator.Temp);
             foreach (var (_, _, entity) in SystemAPI.Query<DynamicBuffer<DamageEvent>, RefRO<ScenarioSide>>()

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
@@ -19,6 +19,8 @@ using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine;
+using AlignmentTriplet = Space4X.Registry.AlignmentTriplet;
+using IndividualStats = Space4X.Registry.IndividualStats;
 
 namespace Space4x.Scenario
 {
@@ -972,9 +974,9 @@ namespace Space4x.Scenario
             };
         }
 
-        private static PureDOTS.Runtime.Individual.IndividualStats BuildStats(float command, float tactics, float logistics, float diplomacy, float engineering, float resolve)
+        private static IndividualStats BuildStats(float command, float tactics, float logistics, float diplomacy, float engineering, float resolve)
         {
-            return new PureDOTS.Runtime.Individual.IndividualStats
+            return new IndividualStats
             {
                 Command = (half)math.clamp(command, 0f, 100f),
                 Tactics = (half)math.clamp(tactics, 0f, 100f),
@@ -1057,9 +1059,9 @@ namespace Space4x.Scenario
 
         private struct CaptainProfileTemplate
         {
-            public PureDOTS.Runtime.Individual.AlignmentTriplet Alignment;
+            public AlignmentTriplet Alignment;
             public BehaviorDisposition Behavior;
-            public PureDOTS.Runtime.Individual.IndividualStats Stats;
+            public IndividualStats Stats;
             public PhysiqueFinesseWill Physique;
             public DerivedCapacities Capacities;
             public PersonalityAxes Personality;

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
@@ -972,9 +972,9 @@ namespace Space4x.Scenario
             };
         }
 
-        private static IndividualStats BuildStats(float command, float tactics, float logistics, float diplomacy, float engineering, float resolve)
+        private static PureDOTS.Runtime.Individual.IndividualStats BuildStats(float command, float tactics, float logistics, float diplomacy, float engineering, float resolve)
         {
-            return new IndividualStats
+            return new PureDOTS.Runtime.Individual.IndividualStats
             {
                 Command = (half)math.clamp(command, 0f, 100f),
                 Tactics = (half)math.clamp(tactics, 0f, 100f),
@@ -1057,9 +1057,9 @@ namespace Space4x.Scenario
 
         private struct CaptainProfileTemplate
         {
-            public AlignmentTriplet Alignment;
+            public PureDOTS.Runtime.Individual.AlignmentTriplet Alignment;
             public BehaviorDisposition Behavior;
-            public IndividualStats Stats;
+            public PureDOTS.Runtime.Individual.IndividualStats Stats;
             public PhysiqueFinesseWill Physique;
             public DerivedCapacities Capacities;
             public PersonalityAxes Personality;

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialAbilitySystem.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialAbilitySystem.cs
@@ -58,7 +58,8 @@ namespace Space4x.Scenario
                 }
 
                 var specialEnergy = em.GetComponentData<ShipSpecialEnergyState>(flagshipEntity);
-                if (!ResourcePoolMath.TrySpend(ref specialEnergy.Current, Space4XFleetcrawlSpecialEnergyRules.SpecialAbilityCost))
+                var currentSpecialEnergy = specialEnergy.Current;
+                if (!ResourcePoolMath.TrySpend(ref currentSpecialEnergy, Space4XFleetcrawlSpecialEnergyRules.SpecialAbilityCost))
                 {
                     specialEnergy.FailedSpendAttempts =
                         (ushort)math.min((int)ushort.MaxValue, specialEnergy.FailedSpendAttempts + 1);
@@ -70,6 +71,7 @@ namespace Space4x.Scenario
                     continue;
                 }
 
+                specialEnergy.Current = currentSpecialEnergy;
                 specialEnergy.LastSpent = Space4XFleetcrawlSpecialEnergyRules.SpecialAbilityCost;
                 specialEnergy.LastSpendTick = tick;
                 em.SetComponentData(flagshipEntity, specialEnergy);

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs
@@ -5,7 +5,7 @@ using PureDOTS.Runtime.Physics;
 using Space4X.Runtime.Interaction;
 using Unity.Collections;
 using Unity.Entities;
-using RuntimeHandState = PureDOTS.Runtime.Components.HandState;
+using RuntimeHandState = PureDOTS.Runtime.Hand.HandState;
 
 namespace Space4X.Systems.Interaction
 {

--- a/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs
+++ b/Assets/Scripts/Space4x/Systems/Interaction/Space4XDivineHandModeExitCleanupSystem.cs
@@ -5,6 +5,7 @@ using PureDOTS.Runtime.Physics;
 using Space4X.Runtime.Interaction;
 using Unity.Collections;
 using Unity.Entities;
+using RuntimeHandState = PureDOTS.Runtime.Components.HandState;
 
 namespace Space4X.Systems.Interaction
 {
@@ -26,7 +27,7 @@ namespace Space4X.Systems.Interaction
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<Space4XControlModeRuntimeState>();
-            state.RequireForUpdate<HandState>();
+            state.RequireForUpdate<RuntimeHandState>();
         }
 
         public void OnUpdate(ref SystemState state)
@@ -50,7 +51,7 @@ namespace Space4X.Systems.Interaction
             var ecb = new EntityCommandBuffer(Allocator.Temp);
 
             foreach (var (handStateRef, commandBuffer, handEntity) in
-                     SystemAPI.Query<RefRW<HandState>, DynamicBuffer<HandCommand>>().WithEntityAccess())
+                     SystemAPI.Query<RefRW<RuntimeHandState>, DynamicBuffer<HandCommand>>().WithEntityAccess())
             {
                 var handState = handStateRef.ValueRO;
                 commandBuffer.Clear();

--- a/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlSpecialEnergyTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XFleetcrawlSpecialEnergyTests.cs
@@ -23,7 +23,7 @@ namespace Space4X.Tests
             var flagship = em.CreateEntity(
                 typeof(LocalTransform),
                 typeof(Space4XFleetcrawlPlayerDirective),
-                typeof(PlayerFlagshipTag),
+                typeof(Space4x.Scenario.PlayerFlagshipTag),
                 typeof(Space4XRunPlayerTag),
                 typeof(ShipSpecialEnergyState));
             em.SetComponentData(flagship, new LocalTransform
@@ -85,7 +85,7 @@ namespace Space4X.Tests
             var flagship = em.CreateEntity(
                 typeof(LocalTransform),
                 typeof(Space4XFleetcrawlPlayerDirective),
-                typeof(PlayerFlagshipTag),
+                typeof(Space4x.Scenario.PlayerFlagshipTag),
                 typeof(Space4XRunPlayerTag),
                 typeof(ShipSpecialEnergyState));
             em.SetComponentData(flagship, new LocalTransform


### PR DESCRIPTION
## Summary
- pin flagship progression queries to Space4x.Scenario.PlayerFlagshipTag to satisfy source-gen component constraints
- disambiguate captain template/stat types to PureDOTS.Runtime.Individual.* in fleetcrawl room systems

## Why
- unblocks Buildbox ScriptCompilation errors (SGQC001, CS0104) encountered while chasing pipeline exit 0
