### PR TITLE
Fix duplicate Fleetcrawl purchase enum on main

### DIFF
--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlEconomySystem.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlEconomySystem.cs
@@ -12,7 +12,10 @@ namespace Space4x.Scenario
         DamageMultiplier = 1,
         CooldownMultiplier = 2,
         HealHullPercent = 3,
-        RerollToken = 4
+        RerollToken = 4,
+        DamageBoost = DamageMultiplier,
+        CooldownTrim = CooldownMultiplier,
+        Heal = HealHullPercent
     }
 
     public struct Space4XFleetcrawlPurchaseRequest : IComponentData

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlUiBridge.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlUiBridge.cs
@@ -17,14 +17,6 @@ namespace Space4x.Scenario
         public int OfferIndex;
     }
 
-    public enum Space4XFleetcrawlPurchaseKind : byte
-    {
-        DamageBoost = 0,
-        CooldownTrim = 1,
-        Heal = 2,
-        RerollToken = 3
-    }
-
     public struct Space4XRunPendingPurchaseRequest : IComponentData
     {
         public int RoomIndex;


### PR DESCRIPTION
## Summary
- remove duplicate Space4XFleetcrawlPurchaseKind enum definition from Space4XFleetcrawlUiBridge.cs
- keep canonical enum in Space4XFleetcrawlEconomySystem.cs
- add compatibility aliases (DamageBoost, CooldownTrim, Heal) to preserve existing UI callsites

## Why
Mainline buildbox currently fails with CS0101 duplicate type + cascading source-gen errors.
