### PR TITLE
fix: burndown main compile blockers after stash sync

### DIFF
--- a/Assets/Scripts/Space4x/Diagnostics/Space4XScenarioReferenceProbe.cs
+++ b/Assets/Scripts/Space4x/Diagnostics/Space4XScenarioReferenceProbe.cs
@@ -18,11 +18,11 @@ namespace Space4X.Diagnostics
             Space4XModeSelectionState.EnsureInitialized();
             Space4XModeSelectionState.GetCurrentScenario(out var modeScenarioId, out var modeScenarioPath, out var modeSeed);
 
-            var envMode = Environment.GetEnvironmentVariable(Space4XModeSelectionState.ModeEnvVar);
-            var envScenarioPath = Environment.GetEnvironmentVariable(Space4XModeSelectionState.ScenarioPathEnvVar);
+            var envMode = System.Environment.GetEnvironmentVariable(Space4XModeSelectionState.ModeEnvVar);
+            var envScenarioPath = System.Environment.GetEnvironmentVariable(Space4XModeSelectionState.ScenarioPathEnvVar);
             var scene = SceneManager.GetActiveScene();
 
-            Debug.Log(
+            UnityEngine.Debug.Log(
                 $"[Space4XScenarioRef] scene='{scene.name}' mode={Space4XModeSelectionState.CurrentMode} " +
                 $"mode_scenario_id='{modeScenarioId}' mode_scenario_path='{modeScenarioPath}' mode_seed={modeSeed} " +
                 $"run_scenario_id='{Space4XRunStartSelection.ScenarioId}' run_scenario_path='{Space4XRunStartSelection.ScenarioPath}' " +

--- a/Assets/Scripts/Space4x/Registry/Space4XLeisureSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XLeisureSystem.cs
@@ -422,7 +422,7 @@ namespace Space4X.Registry
                                       aggregate.Overcrowding * 0.65f;
                 leisureStrength = math.clamp(leisureStrength, -0.9f, 0.6f);
 
-                UpsertMoraleModifier(ref moraleModifiers, MoraleModifierSource.Leisure, leisureStrength, currentTick, 0u);
+                UpsertMoraleModifier(moraleModifiers, MoraleModifierSource.Leisure, leisureStrength, currentTick, 0u);
 
                 var espionagePressure = aggregate.EspionageRisk * (1f - (float)security.CounterIntelLevel);
                 var poisonPressure = aggregate.PoisonRisk * (1f - (float)security.FoodSafetyLevel);
@@ -478,7 +478,7 @@ namespace Space4X.Registry
                             Tick = currentTick
                         });
 
-                        UpsertMoraleModifier(ref moraleModifiers, MoraleModifierSource.Espionage, -severity, currentTick, 120u);
+                        UpsertMoraleModifier(moraleModifiers, MoraleModifierSource.Espionage, -severity, currentTick, 120u);
 
                         if (_suspicionLookup.HasComponent(entity))
                         {
@@ -626,7 +626,7 @@ namespace Space4X.Registry
         }
 
         private static void UpsertMoraleModifier(
-            ref DynamicBuffer<MoraleModifier> buffer,
+            DynamicBuffer<MoraleModifier> buffer,
             MoraleModifierSource source,
             float strength,
             uint currentTick,

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlEconomySystem.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlEconomySystem.cs
@@ -127,7 +127,7 @@ namespace Space4x.Scenario
             return Space4XFleetcrawlPurchaseKind.Unknown;
         }
 
-        private static bool ApplyPurchase(
+        private bool ApplyPurchase(
             ref SystemState state,
             Space4XFleetcrawlPurchaseKind kind,
             ref Space4XRunReactiveModifiers modifiers,

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlRoomSystems.cs
@@ -1620,8 +1620,8 @@ namespace Space4x.Scenario
             var missingRequired = remainingRequiredTags.Count == 0
                 ? "-"
                 : string.Join(",", remainingRequiredTags.ToArray());
-            var fallbackWildcard = NormalizeToken(unknownSelectionRules.fallbackWildcard, "hazard");
-            return $"objective=[{objectiveCsv}] enemy=[{enemyCsv}] hazard=[{hazardCsv}] wildcard=[{wildcardCsv}] total_cost={totalCost}/{math.max(1, finalBudget)} missing_required={missingRequired} over_budget={overflowCount} fallback_wildcard={fallbackWildcard}";
+            var fallbackWildcardToken = NormalizeToken(unknownSelectionRules.fallbackWildcard, "hazard");
+            return $"objective=[{objectiveCsv}] enemy=[{enemyCsv}] hazard=[{hazardCsv}] wildcard=[{wildcardCsv}] total_cost={totalCost}/{math.max(1, finalBudget)} missing_required={missingRequired} over_budget={overflowCount} fallback_wildcard={fallbackWildcardToken}";
         }
 
         private static void FillLanePacks(

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialAbilitySystem.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlSpecialAbilitySystem.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using PureDOTS.Runtime.Math;
 using PureDOTS.Runtime.Components;
 using Space4X.Registry;
+using Space4X.Runtime;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;

--- a/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlUiBridge.cs
+++ b/Assets/Scripts/Space4x/Scenario/Space4XFleetcrawlUiBridge.cs
@@ -32,6 +32,16 @@ namespace Space4x.Scenario
         public FixedString64Bytes RewardId;
     }
 
+    public struct Space4XFleetcrawlBlueprintDefinition
+    {
+        public Space4XRunBlueprintKind Kind;
+        public FixedString64Bytes BlueprintId;
+        public FixedString64Bytes BaseModuleId;
+        public FixedString64Bytes ManufacturerId;
+        public FixedString64Bytes PartA;
+        public FixedString64Bytes PartB;
+    }
+
     public enum Space4XFleetcrawlInputMode : byte
     {
         Auto = 0,
@@ -259,6 +269,93 @@ namespace Space4x.Scenario
             }
 
             return blueprintId.ToString();
+        }
+
+        public static bool TryResolveBlueprintDefinition(string blueprintId, out Space4XFleetcrawlBlueprintDefinition definition)
+        {
+            if (string.IsNullOrWhiteSpace(blueprintId))
+            {
+                definition = default;
+                return false;
+            }
+
+            return TryResolveBlueprintDefinition(new FixedString64Bytes(blueprintId.Trim()), out definition);
+        }
+
+        public static bool TryResolveBlueprintDefinition(in FixedString64Bytes blueprintId, out Space4XFleetcrawlBlueprintDefinition definition)
+        {
+            if (blueprintId.Equals(new FixedString64Bytes("weapon_laser_prismworks_coreA_lensBeam")))
+            {
+                definition = new Space4XFleetcrawlBlueprintDefinition
+                {
+                    Kind = Space4XRunBlueprintKind.Weapon,
+                    BlueprintId = blueprintId,
+                    BaseModuleId = new FixedString64Bytes("weapon_laser"),
+                    ManufacturerId = new FixedString64Bytes("prismworks"),
+                    PartA = new FixedString64Bytes("coreA"),
+                    PartB = new FixedString64Bytes("lensBeam")
+                };
+                return true;
+            }
+
+            if (blueprintId.Equals(new FixedString64Bytes("weapon_kinetic_baseline_coreB_barrelKinetic")))
+            {
+                definition = new Space4XFleetcrawlBlueprintDefinition
+                {
+                    Kind = Space4XRunBlueprintKind.Weapon,
+                    BlueprintId = blueprintId,
+                    BaseModuleId = new FixedString64Bytes("weapon_kinetic"),
+                    ManufacturerId = new FixedString64Bytes("baseline"),
+                    PartA = new FixedString64Bytes("coreB"),
+                    PartB = new FixedString64Bytes("barrelKinetic")
+                };
+                return true;
+            }
+
+            if (blueprintId.Equals(new FixedString64Bytes("reactor_prismworks_coreA_coolingStable")))
+            {
+                definition = new Space4XFleetcrawlBlueprintDefinition
+                {
+                    Kind = Space4XRunBlueprintKind.Reactor,
+                    BlueprintId = blueprintId,
+                    BaseModuleId = new FixedString64Bytes("reactor"),
+                    ManufacturerId = new FixedString64Bytes("prismworks"),
+                    PartA = new FixedString64Bytes("coreA"),
+                    PartB = new FixedString64Bytes("coolingStable")
+                };
+                return true;
+            }
+
+            if (blueprintId.Equals(new FixedString64Bytes("hangar_prismworks_guidanceDroneLink_lensBeam")))
+            {
+                definition = new Space4XFleetcrawlBlueprintDefinition
+                {
+                    Kind = Space4XRunBlueprintKind.Hangar,
+                    BlueprintId = blueprintId,
+                    BaseModuleId = new FixedString64Bytes("hangar"),
+                    ManufacturerId = new FixedString64Bytes("prismworks"),
+                    PartA = new FixedString64Bytes("guidanceDroneLink"),
+                    PartB = new FixedString64Bytes("lensBeam")
+                };
+                return true;
+            }
+
+            definition = default;
+            return false;
+        }
+
+        public static Space4XRunInstalledBlueprint ToInstalledBlueprint(in Space4XFleetcrawlBlueprintDefinition definition, byte version)
+        {
+            return new Space4XRunInstalledBlueprint
+            {
+                BlueprintId = definition.BlueprintId,
+                BaseModuleId = definition.BaseModuleId,
+                ManufacturerId = definition.ManufacturerId,
+                PartA = definition.PartA,
+                PartB = definition.PartB,
+                Kind = definition.Kind,
+                Version = version
+            };
         }
 
         public static string DescribePurchase(Space4XFleetcrawlPurchaseKind kind)


### PR DESCRIPTION
## Summary\n- fixes namespace resolution issues in scenario diagnostics (System.Environment, UnityEngine.Debug)\n- resolves foreach/ref morale modifier compile issue in leisure system\n- fixes static SystemAPI.Query usage in fleetcrawl purchase system\n- resolves duplicate local name in room pack summary builder\n- adds missing Space4X.Runtime import for special ability energy state\n- restores missing fleetcrawl UI bridge blueprint helpers used by starter loadout override\n\n## Validation\n- laptop iterator flow: no local validation loop (validator/buildbox to run)\n\n## Notes\n- scoped to compile unblock only; no gameplay behavior redesign in this patch.