### PR TITLE
feat: package laptop stashes (status, leisure-education, tax)

### DIFF
--- a/Assets/Scripts/Space4x/Registry/Space4XAreaEffectComponents.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XAreaEffectComponents.cs
@@ -107,6 +107,8 @@ namespace Space4X.Registry
         public HazardTypeId HazardType;
         public Space4XDamageType DamageType;
         public float Magnitude;
+        public uint DurationTicks;
+        public byte StackCount;
         public uint Tick;
     }
 }

--- a/Assets/Scripts/Space4x/Registry/Space4XAreaEffectSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XAreaEffectSystem.cs
@@ -99,6 +99,7 @@ namespace Space4X.Registry
             var hasPhysicsWorld = SystemAPI.TryGetSingleton<PhysicsWorldSingleton>(out var physicsWorld);
             var ecb = new EntityCommandBuffer(Allocator.Temp);
             var modulesWithPendingLimbBuffer = new NativeParallelHashSet<Entity>(64, Allocator.Temp);
+            var targetsWithPendingStatusBuffer = new NativeParallelHashSet<Entity>(64, Allocator.Temp);
 
             var targets = new NativeList<TargetSnapshot>(Allocator.Temp);
             foreach (var (transform, entity) in SystemAPI.Query<RefRO<LocalTransform>>().WithEntityAccess())
@@ -224,7 +225,8 @@ namespace Space4X.Registry
                         appliedMagnitude,
                         currentTick,
                         ref ecb,
-                        ref modulesWithPendingLimbBuffer);
+                        ref modulesWithPendingLimbBuffer,
+                        ref targetsWithPendingStatusBuffer);
                 }
 
                 var updated = emitterRef.ValueRO;
@@ -244,6 +246,7 @@ namespace Space4X.Registry
             ecb.Playback(state.EntityManager);
             ecb.Dispose();
             modulesWithPendingLimbBuffer.Dispose();
+            targetsWithPendingStatusBuffer.Dispose();
             occluders.Dispose();
             targets.Dispose();
         }
@@ -255,7 +258,8 @@ namespace Space4X.Registry
             float magnitude,
             uint currentTick,
             ref EntityCommandBuffer ecb,
-            ref NativeParallelHashSet<Entity> modulesWithPendingLimbBuffer)
+            ref NativeParallelHashSet<Entity> modulesWithPendingLimbBuffer,
+            ref NativeParallelHashSet<Entity> targetsWithPendingStatusBuffer)
         {
             if ((emitter.ImpactMask & Space4XAreaEffectImpactMask.HullDamage) != 0 &&
                 _hullLookup.HasComponent(target))
@@ -356,9 +360,31 @@ namespace Space4X.Registry
                     HazardType = emitter.HazardType,
                     DamageType = emitter.DamageType,
                     Magnitude = magnitude,
+                    DurationTicks = emitter.DisableDurationTicks,
+                    StackCount = 1,
                     Tick = currentTick
                 });
+                return;
             }
+
+            if (!targetsWithPendingStatusBuffer.Contains(target))
+            {
+                ecb.AddBuffer<Space4XStatusEffectEvent>(target);
+                targetsWithPendingStatusBuffer.Add(target);
+            }
+
+            ecb.AppendToBuffer(target, new Space4XStatusEffectEvent
+            {
+                SourceEntity = source,
+                Scope = emitter.Scope,
+                ImpactMask = emitter.ImpactMask,
+                HazardType = emitter.HazardType,
+                DamageType = emitter.DamageType,
+                Magnitude = magnitude,
+                DurationTicks = emitter.DisableDurationTicks,
+                StackCount = 1,
+                Tick = currentTick
+            });
         }
 
         private static void UpsertSubsystemDisable(

--- a/Assets/Scripts/Space4x/Registry/Space4XLeisureComponents.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XLeisureComponents.cs
@@ -21,7 +21,10 @@ namespace Space4X.Registry
         Restaurant = 12,
         Arena = 13,
         OrbitalArena = 14,
-        Temple = 15
+        Temple = 15,
+        School = 16,
+        University = 17,
+        TrainingGround = 18
     }
 
     public enum ArenaProgramTier : byte
@@ -45,7 +48,8 @@ namespace Space4X.Registry
         SpyRecruitment = 1,
         PoisonedSupply = 2,
         SleeperAssassin = 3,
-        BriberyDemand = 4
+        BriberyDemand = 4,
+        FacultySubversion = 5
     }
 
     /// <summary>
@@ -74,6 +78,12 @@ namespace Space4X.Registry
         public float LootYieldRate;
         public float SalvageRightsRate;
         public float ReputationYieldRate;
+        public float EducationRate;
+        public float TrainingRate;
+        public float WisdomRate;
+        public float ResearchRate;
+        public float IdeologyPressure;
+        public float FacultyBriberyRisk;
 
         public static LeisureFacilityLimb CrewQuarters(float housingSlots = 12f)
         {
@@ -227,6 +237,105 @@ namespace Space4X.Registry
                 ReputationYieldRate = 0.07f
             };
         }
+
+        public static LeisureFacilityLimb School()
+        {
+            return new LeisureFacilityLimb
+            {
+                Type = LeisureFacilityType.School,
+                ArenaTier = ArenaProgramTier.Exhibition,
+                HousingCapacity = 0f,
+                EntertainmentRate = 0.03f,
+                ComfortRate = 0.03f,
+                SocialRate = 0.025f,
+                NourishmentRate = 0.01f,
+                AmbientLawBias = 0.1f,
+                AmbientGoodBias = 0.05f,
+                AmbientIntegrityBias = 0.08f,
+                AmbientIntensity = 0.06f,
+                EspionageRisk = 0.02f,
+                PoisonRisk = 0.02f,
+                AssassinationRisk = 0.015f,
+                Illicitness = 0f,
+                BriberyPressure = 0.02f,
+                ParticipationPurseRate = 0f,
+                LootYieldRate = 0f,
+                SalvageRightsRate = 0f,
+                ReputationYieldRate = 0.02f,
+                EducationRate = 0.08f,
+                TrainingRate = 0.02f,
+                WisdomRate = 0.04f,
+                ResearchRate = 0.02f,
+                IdeologyPressure = 0.04f,
+                FacultyBriberyRisk = 0.03f
+            };
+        }
+
+        public static LeisureFacilityLimb University()
+        {
+            return new LeisureFacilityLimb
+            {
+                Type = LeisureFacilityType.University,
+                ArenaTier = ArenaProgramTier.Exhibition,
+                HousingCapacity = 10f,
+                EntertainmentRate = 0.02f,
+                ComfortRate = 0.04f,
+                SocialRate = 0.035f,
+                NourishmentRate = 0.012f,
+                AmbientLawBias = 0.08f,
+                AmbientGoodBias = 0.06f,
+                AmbientIntegrityBias = 0.1f,
+                AmbientIntensity = 0.08f,
+                EspionageRisk = 0.03f,
+                PoisonRisk = 0.02f,
+                AssassinationRisk = 0.02f,
+                Illicitness = 0f,
+                BriberyPressure = 0.03f,
+                ParticipationPurseRate = 0f,
+                LootYieldRate = 0f,
+                SalvageRightsRate = 0f,
+                ReputationYieldRate = 0.04f,
+                EducationRate = 0.11f,
+                TrainingRate = 0.03f,
+                WisdomRate = 0.06f,
+                ResearchRate = 0.08f,
+                IdeologyPressure = 0.06f,
+                FacultyBriberyRisk = 0.05f
+            };
+        }
+
+        public static LeisureFacilityLimb TrainingGround()
+        {
+            return new LeisureFacilityLimb
+            {
+                Type = LeisureFacilityType.TrainingGround,
+                ArenaTier = ArenaProgramTier.Exhibition,
+                HousingCapacity = 0f,
+                EntertainmentRate = 0.04f,
+                ComfortRate = 0.015f,
+                SocialRate = 0.03f,
+                NourishmentRate = 0.008f,
+                AmbientLawBias = 0.06f,
+                AmbientGoodBias = -0.01f,
+                AmbientIntegrityBias = 0.03f,
+                AmbientIntensity = 0.05f,
+                EspionageRisk = 0.02f,
+                PoisonRisk = 0.02f,
+                AssassinationRisk = 0.02f,
+                Illicitness = 0f,
+                BriberyPressure = 0.02f,
+                ParticipationPurseRate = 0f,
+                LootYieldRate = 0f,
+                SalvageRightsRate = 0f,
+                ReputationYieldRate = 0.02f,
+                EducationRate = 0.02f,
+                TrainingRate = 0.1f,
+                WisdomRate = 0.02f,
+                ResearchRate = 0.01f,
+                IdeologyPressure = 0.03f,
+                FacultyBriberyRisk = 0.03f
+            };
+        }
     }
 
     /// <summary>
@@ -278,6 +387,9 @@ namespace Space4X.Registry
         public half ThirdBlood;
         public half SanguinisExtremis;
         public half Temple;
+        public half School;
+        public half University;
+        public half Training;
 
         public static LeisurePreferenceProfile Neutral => new LeisurePreferenceProfile
         {
@@ -295,7 +407,10 @@ namespace Space4X.Registry
             OrbitalArena = (half)0.5f,
             ThirdBlood = (half)0.35f,
             SanguinisExtremis = (half)0.1f,
-            Temple = (half)0.5f
+            Temple = (half)0.5f,
+            School = (half)0.6f,
+            University = (half)0.6f,
+            Training = (half)0.55f
         };
 
         public static LeisurePreferenceProfile FromAlignment(in AlignmentTriplet alignment)
@@ -323,8 +438,76 @@ namespace Space4X.Registry
             profile.ThirdBlood = (half)math.saturate(0.1f + 0.75f * chaos + 0.15f * evil);
             profile.SanguinisExtremis = (half)math.saturate(chaos * corruption * (0.35f + 0.65f * evil));
             profile.Temple = (half)math.saturate(0.15f + 0.5f * integrity + 0.2f * law + 0.15f * good);
+            profile.School = (half)math.saturate(0.2f + 0.45f * law + 0.25f * integrity + 0.1f * good);
+            profile.University = (half)math.saturate(0.25f + 0.35f * law + 0.25f * integrity + 0.15f * good);
+            profile.Training = (half)math.saturate(0.25f + 0.3f * law + 0.25f * chaos + 0.1f * evil);
             return profile;
         }
+    }
+
+    /// <summary>
+    /// Tunable education/training schedule and policy knobs.
+    /// This is intentionally data-driven so pacing can be tuned without code changes.
+    /// </summary>
+    public struct LeisureEducationPolicy : IComponentData
+    {
+        public byte Enabled;
+        public float DayLengthHours;
+        public float SchoolStartHour;
+        public float SchoolDurationHours;
+        public float UniversityShiftAStartHour;
+        public float UniversityShiftBStartHour;
+        public float UniversityShiftDurationHours;
+        public float TrainingStartHour;
+        public float TrainingDurationHours;
+        public half OffHoursEfficiency;
+        public half EnrollmentRatio;
+        public half TutorQuality01;
+        public half ProfessorQuality01;
+        public half AssistantCoverage01;
+        public half Standards01;
+        public half IdeologyResistance01;
+        public half BriberyOversight01;
+        public float SkillGainScale;
+        public float WisdomGainScale;
+        public float ResearchScale;
+
+        public static LeisureEducationPolicy Default => new LeisureEducationPolicy
+        {
+            Enabled = 1,
+            DayLengthHours = 24f,
+            SchoolStartHour = 8f,
+            SchoolDurationHours = 4f,
+            UniversityShiftAStartHour = 8f,
+            UniversityShiftBStartHour = 14f,
+            UniversityShiftDurationHours = 4f,
+            TrainingStartHour = 18f,
+            TrainingDurationHours = 3f,
+            OffHoursEfficiency = (half)0.2f,
+            EnrollmentRatio = (half)0.45f,
+            TutorQuality01 = (half)0.55f,
+            ProfessorQuality01 = (half)0.6f,
+            AssistantCoverage01 = (half)0.45f,
+            Standards01 = (half)0.6f,
+            IdeologyResistance01 = (half)0.4f,
+            BriberyOversight01 = (half)0.45f,
+            SkillGainScale = 0.5f,
+            WisdomGainScale = 0.2f,
+            ResearchScale = 0.8f
+        };
+    }
+
+    /// <summary>
+    /// Runtime education/training progress snapshot for UI/telemetry.
+    /// </summary>
+    public struct LeisureEducationProgress : IComponentData
+    {
+        public float LastLearningOutput;
+        public float LastTrainingOutput;
+        public float LastResearchOutput;
+        public float LastIdeologyPressure;
+        public float LifetimeResearch;
+        public uint LastUpdateTick;
     }
 
     /// <summary>
@@ -356,6 +539,12 @@ namespace Space4X.Registry
         public float ComfortRate;
         public float SocialRate;
         public float NourishmentRate;
+        public float EducationRate;
+        public float UniversityRate;
+        public float TrainingRate;
+        public float WisdomRate;
+        public float ResearchRate;
+        public float IdeologyPressure;
         public float PreferenceFit;
         public float Overcrowding;
         public float AmbientLawBias;
@@ -415,6 +604,9 @@ namespace Space4X.Registry
                 LeisureFacilityType.Arena => profile.Arena,
                 LeisureFacilityType.OrbitalArena => profile.OrbitalArena,
                 LeisureFacilityType.Temple => profile.Temple,
+                LeisureFacilityType.School => profile.School,
+                LeisureFacilityType.University => profile.University,
+                LeisureFacilityType.TrainingGround => profile.Training,
                 LeisureFacilityType.CrewQuarters => math.max(profile.BioDeck, profile.Restaurant) * 0.5f,
                 LeisureFacilityType.Barracks => math.max(profile.Holotheater, profile.Casino) * 0.35f,
                 _ => 0.5f

--- a/Assets/Scripts/Space4x/Registry/Space4XLeisureSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XLeisureSystem.cs
@@ -31,6 +31,11 @@ namespace Space4X.Registry
         private ComponentLookup<AlignmentTriplet> _alignmentLookup;
         private ComponentLookup<SupplyStatus> _supplyLookup;
         private ComponentLookup<SuspicionScore> _suspicionLookup;
+        private ComponentLookup<LeisureEducationPolicy> _educationPolicyLookup;
+        private ComponentLookup<LeisureEducationProgress> _educationProgressLookup;
+        private ComponentLookup<SkillExperienceGain> _xpLookup;
+        private ComponentLookup<CrewSkills> _skillsLookup;
+        private ComponentLookup<PureDOTS.Runtime.Stats.WisdomStat> _wisdomLookup;
 
         [BurstCompile]
         public void OnCreate(ref SystemState state)
@@ -51,6 +56,11 @@ namespace Space4X.Registry
             _alignmentLookup = state.GetComponentLookup<AlignmentTriplet>(false);
             _supplyLookup = state.GetComponentLookup<SupplyStatus>(false);
             _suspicionLookup = state.GetComponentLookup<SuspicionScore>(false);
+            _educationPolicyLookup = state.GetComponentLookup<LeisureEducationPolicy>(false);
+            _educationProgressLookup = state.GetComponentLookup<LeisureEducationProgress>(false);
+            _xpLookup = state.GetComponentLookup<SkillExperienceGain>(false);
+            _skillsLookup = state.GetComponentLookup<CrewSkills>(false);
+            _wisdomLookup = state.GetComponentLookup<PureDOTS.Runtime.Stats.WisdomStat>(false);
         }
 
         [BurstCompile]
@@ -79,8 +89,15 @@ namespace Space4X.Registry
             _alignmentLookup.Update(ref state);
             _supplyLookup.Update(ref state);
             _suspicionLookup.Update(ref state);
+            _educationPolicyLookup.Update(ref state);
+            _educationProgressLookup.Update(ref state);
+            _xpLookup.Update(ref state);
+            _skillsLookup.Update(ref state);
+            _wisdomLookup.Update(ref state);
 
             var currentTick = time.Tick;
+            var fixedDeltaTime = time.FixedDeltaTime;
+            var hasSkillLog = SystemAPI.TryGetSingletonBuffer<SkillChangeLogEntry>(out var skillLog);
 
             foreach (var (needRef, preferenceRef, securityRef, aggregateRef, moraleModifiers, incidents, opportunities, entity) in
                 SystemAPI.Query<
@@ -96,6 +113,12 @@ namespace Space4X.Registry
                 var needs = needRef.ValueRO;
                 var profile = preferenceRef.ValueRO;
                 var security = securityRef.ValueRO;
+                var educationPolicy = _educationPolicyLookup.HasComponent(entity)
+                    ? _educationPolicyLookup[entity]
+                    : LeisureEducationPolicy.Default;
+                var educationProgress = _educationProgressLookup.HasComponent(entity)
+                    ? _educationProgressLookup[entity]
+                    : default;
 
                 var chaos = 0.5f;
                 var corruption = 0.5f;
@@ -117,6 +140,12 @@ namespace Space4X.Registry
                 var ambientGood = 0f;
                 var ambientIntegrity = 0f;
                 var ambientWeight = 0f;
+                var schoolRate = 0f;
+                var universityRate = 0f;
+                var trainingRate = 0f;
+                var wisdomRate = 0f;
+                var researchRate = 0f;
+                var ideologyRate = 0f;
 
                 var arenaOpportunity = 0f;
                 var orbitalOpportunity = 0f;
@@ -140,6 +169,8 @@ namespace Space4X.Registry
                 var topPoisonModule = Entity.Null;
                 var topAssassinModule = Entity.Null;
                 var topBriberyModule = Entity.Null;
+                var topFacultySubversionRisk = 0f;
+                var topFacultySubversionModule = Entity.Null;
 
                 if (_moduleSlotsLookup.HasBuffer(entity))
                 {
@@ -188,6 +219,29 @@ namespace Space4X.Registry
                             in profile,
                             ref preferenceWeighted,
                             ref preferenceWeightTotal);
+
+                        var educationContribution = math.max(0f, facility.EducationRate) * integrity;
+                        var trainingContribution = math.max(0f, facility.TrainingRate) * integrity;
+                        var wisdomContribution = math.max(0f, facility.WisdomRate) * integrity;
+                        var researchContribution = math.max(0f, facility.ResearchRate) * integrity;
+                        var ideologyContribution = math.max(0f, facility.IdeologyPressure) * integrity;
+
+                        switch (facility.Type)
+                        {
+                            case LeisureFacilityType.School:
+                                schoolRate += educationContribution;
+                                break;
+                            case LeisureFacilityType.University:
+                                universityRate += educationContribution;
+                                break;
+                            case LeisureFacilityType.TrainingGround:
+                                trainingRate += trainingContribution + educationContribution * 0.35f;
+                                break;
+                        }
+
+                        wisdomRate += wisdomContribution;
+                        researchRate += researchContribution;
+                        ideologyRate += ideologyContribution;
 
                         var ambientIntensity = math.max(0f, facility.AmbientIntensity) * integrity;
                         if (ambientIntensity > 1e-5f)
@@ -288,6 +342,13 @@ namespace Space4X.Registry
                             topBriberyRisk = briberyContribution;
                             topBriberyModule = module;
                         }
+
+                        var facultySubversionContribution = math.max(0f, facility.FacultyBriberyRisk) * integrity;
+                        if (facultySubversionContribution > topFacultySubversionRisk)
+                        {
+                            topFacultySubversionRisk = facultySubversionContribution;
+                            topFacultySubversionModule = module;
+                        }
                     }
                 }
 
@@ -341,6 +402,12 @@ namespace Space4X.Registry
                 aggregate.LootYieldRate = lootRate;
                 aggregate.SalvageRightsRate = salvageRate;
                 aggregate.ReputationYieldRate = reputationRate;
+                aggregate.EducationRate = schoolRate;
+                aggregate.UniversityRate = universityRate;
+                aggregate.TrainingRate = trainingRate;
+                aggregate.WisdomRate = wisdomRate;
+                aggregate.ResearchRate = researchRate;
+                aggregate.IdeologyPressure = ideologyRate;
 
                 if (aggregate.AmbientIntensity > 1e-5f)
                 {
@@ -416,6 +483,86 @@ namespace Space4X.Registry
                 needs.LastUpdateTick = currentTick;
                 needRef.ValueRW = needs;
 
+                var schoolWindow = 0f;
+                var universityWindow = 0f;
+                var trainingWindow = 0f;
+                ResolveEducationScheduleWeights(
+                    currentTick,
+                    fixedDeltaTime,
+                    in educationPolicy,
+                    out schoolWindow,
+                    out universityWindow,
+                    out trainingWindow);
+
+                var educationEnabled = educationPolicy.Enabled != 0;
+                if (!educationEnabled)
+                {
+                    schoolWindow = 0f;
+                    universityWindow = 0f;
+                    trainingWindow = 0f;
+                }
+
+                var activeLearners = math.max(1f, currentCrew * math.max(0.05f, (float)educationPolicy.EnrollmentRatio));
+                var facultyQuality = ResolveFacultyQuality(in educationPolicy);
+                var standards = math.saturate((float)educationPolicy.Standards01);
+                var learningOutput =
+                    (aggregate.EducationRate * schoolWindow + aggregate.UniversityRate * universityWindow) *
+                    facultyQuality * standards / activeLearners;
+                var trainingOutput =
+                    aggregate.TrainingRate * trainingWindow *
+                    (0.45f + 0.55f * facultyQuality) / activeLearners;
+                var wisdomOutput =
+                    aggregate.WisdomRate * (schoolWindow * 0.55f + universityWindow * 0.45f) *
+                    facultyQuality / activeLearners;
+                var researchOutput =
+                    aggregate.ResearchRate * (0.3f + 0.7f * universityWindow) *
+                    facultyQuality * math.max(0f, educationPolicy.ResearchScale);
+                var ideologyPressure =
+                    aggregate.IdeologyPressure *
+                    (1f - math.saturate((float)educationPolicy.IdeologyResistance01)) *
+                    (0.4f + 0.6f * universityWindow);
+
+                var educationMorale =
+                    (learningOutput + trainingOutput) * 2.2f +
+                    researchOutput * 0.75f -
+                    ideologyPressure * 0.35f -
+                    aggregate.Overcrowding * 0.12f;
+                educationMorale = math.clamp(educationMorale, -0.35f, 0.45f);
+                UpsertMoraleModifier(ref moraleModifiers, MoraleModifierSource.Education, educationMorale, currentTick, 0u);
+
+                if (educationEnabled && (learningOutput > 1e-5f || trainingOutput > 1e-5f || researchOutput > 1e-5f))
+                {
+                    ApplyEducationSkillProgress(
+                        entity,
+                        currentTick,
+                        learningOutput,
+                        trainingOutput,
+                        researchOutput,
+                        in educationPolicy,
+                        hasSkillLog,
+                        skillLog);
+
+                    ApplyCrewWisdomGain(
+                        entity,
+                        wisdomOutput,
+                        in educationPolicy,
+                        ref _crewLookup,
+                        ref _wisdomLookup);
+                }
+
+                if (_educationProgressLookup.HasComponent(entity))
+                {
+                    educationProgress.LastLearningOutput = learningOutput;
+                    educationProgress.LastTrainingOutput = trainingOutput;
+                    educationProgress.LastResearchOutput = researchOutput;
+                    educationProgress.LastIdeologyPressure = ideologyPressure;
+                    educationProgress.LifetimeResearch += researchOutput;
+                    educationProgress.LastUpdateTick = currentTick;
+                    _educationProgressLookup[entity] = educationProgress;
+                }
+
+                aggregate.IdeologyPressure = ideologyPressure;
+
                 var needScore = (entertainment + comfort + social + nourishment) * 0.25f;
                 var leisureStrength = (needScore - 0.5f) * 0.55f +
                                       (aggregate.PreferenceFit - 0.5f) * 0.25f -
@@ -428,12 +575,16 @@ namespace Space4X.Registry
                 var poisonPressure = aggregate.PoisonRisk * (1f - (float)security.FoodSafetyLevel);
                 var assassinPressure = aggregate.AssassinationRisk * (1f - (float)security.InternalSecurityLevel);
                 var briberyPressure = aggregate.BriberyRisk * (1f - (float)security.BriberyBudget);
+                var facultySubversionPressure =
+                    topFacultySubversionRisk *
+                    (1f - math.saturate((float)educationPolicy.BriberyOversight01));
 
                 var incidentChance = math.saturate(
                     espionagePressure * (0.3f + chaos * 0.2f) +
                     poisonPressure * 0.3f +
                     assassinPressure * (0.2f + corruption * 0.2f) +
-                    briberyPressure * (0.15f + chaos * 0.25f));
+                    briberyPressure * (0.15f + chaos * 0.25f) +
+                    facultySubversionPressure * (0.1f + corruption * 0.2f));
 
                 var canTriggerIncident = incidents.Length == 0 || currentTick - incidents[incidents.Length - 1].Tick >= 30u;
                 if (incidentChance > 1e-5f && canTriggerIncident)
@@ -456,13 +607,15 @@ namespace Space4X.Registry
                             poisonPressure,
                             assassinPressure,
                             briberyPressure,
+                            facultySubversionPressure,
                             random.NextFloat());
                         var incidentModule = ResolveIncidentSourceModule(
                             incidentType,
                             topEspionageModule,
                             topPoisonModule,
                             topAssassinModule,
-                            topBriberyModule);
+                            topBriberyModule,
+                            topFacultySubversionModule);
 
                         if (incidents.Length >= 32)
                         {
@@ -594,7 +747,7 @@ namespace Space4X.Registry
             aggregate.EspionageRisk += math.max(0f, facility.EspionageRisk) * clampedIntegrity;
             aggregate.PoisonRisk += math.max(0f, facility.PoisonRisk) * clampedIntegrity;
             aggregate.AssassinationRisk += math.max(0f, facility.AssassinationRisk) * clampedIntegrity;
-            aggregate.BriberyRisk += math.max(0f, facility.BriberyPressure + facility.Illicitness * 0.35f) * clampedIntegrity;
+            aggregate.BriberyRisk += math.max(0f, facility.BriberyPressure + facility.Illicitness * 0.35f + facility.FacultyBriberyRisk) * clampedIntegrity;
 
             var preference = LeisureFacilityUtility.ResolvePreferenceWeight(profile, facility.Type);
             var facilityYield = facility.EntertainmentRate + facility.ComfortRate + facility.SocialRate + facility.NourishmentRate;
@@ -710,6 +863,9 @@ namespace Space4X.Registry
             adjusted.ThirdBlood = (half)math.saturate((float)profile.ThirdBlood + warlike * (0.1f + 0.2f * chaos));
             adjusted.SanguinisExtremis = (half)math.saturate((float)profile.SanguinisExtremis + warlike * (0.08f + 0.22f * corruption));
             adjusted.Temple = (half)math.saturate((float)profile.Temple + pacifism * 0.14f - warlike * 0.05f);
+            adjusted.Training = (half)math.saturate((float)profile.Training + warlike * 0.2f);
+            adjusted.School = (half)math.saturate((float)profile.School + pacifism * 0.08f - warlike * 0.04f);
+            adjusted.University = (half)math.saturate((float)profile.University + pacifism * 0.1f - warlike * 0.03f);
             return adjusted;
         }
 
@@ -728,6 +884,207 @@ namespace Space4X.Registry
             var step = math.saturate(ambientStrength) * coupling * 0.02f / math.max(1f, populationScale);
             var next = math.clamp(current + ambientDirection * step * polarity, new float3(-1f), new float3(1f));
             return AlignmentTriplet.FromFloats(next.x, next.y, next.z);
+        }
+
+        private static void ResolveEducationScheduleWeights(
+            uint currentTick,
+            float fixedDeltaTime,
+            in LeisureEducationPolicy policy,
+            out float schoolWindow,
+            out float universityWindow,
+            out float trainingWindow)
+        {
+            schoolWindow = 0f;
+            universityWindow = 0f;
+            trainingWindow = 0f;
+
+            var dayLengthHours = math.max(1f, policy.DayLengthHours);
+            var hourOfDay = math.fmod(currentTick * math.max(0.001f, fixedDeltaTime), dayLengthHours);
+            if (hourOfDay < 0f)
+            {
+                hourOfDay += dayLengthHours;
+            }
+
+            var offHours = math.saturate((float)policy.OffHoursEfficiency);
+
+            var schoolActive = IsWindowActive(hourOfDay, dayLengthHours, policy.SchoolStartHour, policy.SchoolDurationHours);
+            schoolWindow = schoolActive ? 1f : offHours;
+
+            var universityShiftAActive = IsWindowActive(
+                hourOfDay,
+                dayLengthHours,
+                policy.UniversityShiftAStartHour,
+                policy.UniversityShiftDurationHours);
+            var universityShiftBActive = IsWindowActive(
+                hourOfDay,
+                dayLengthHours,
+                policy.UniversityShiftBStartHour,
+                policy.UniversityShiftDurationHours);
+            universityWindow = universityShiftAActive || universityShiftBActive ? 1f : offHours;
+
+            var trainingActive = IsWindowActive(hourOfDay, dayLengthHours, policy.TrainingStartHour, policy.TrainingDurationHours);
+            trainingWindow = trainingActive ? 1f : offHours;
+        }
+
+        private static bool IsWindowActive(
+            float hourOfDay,
+            float dayLengthHours,
+            float startHour,
+            float durationHours)
+        {
+            var duration = math.max(0f, durationHours);
+            if (duration <= 1e-5f)
+            {
+                return false;
+            }
+
+            var start = math.fmod(startHour, dayLengthHours);
+            if (start < 0f)
+            {
+                start += dayLengthHours;
+            }
+
+            var end = start + duration;
+            if (end < dayLengthHours)
+            {
+                return hourOfDay >= start && hourOfDay < end;
+            }
+
+            var wrappedEnd = end - dayLengthHours;
+            return hourOfDay >= start || hourOfDay < wrappedEnd;
+        }
+
+        private static float ResolveFacultyQuality(in LeisureEducationPolicy policy)
+        {
+            var tutor = math.saturate((float)policy.TutorQuality01);
+            var professor = math.saturate((float)policy.ProfessorQuality01);
+            var assistants = math.saturate((float)policy.AssistantCoverage01);
+            return math.saturate(0.35f + tutor * 0.25f + professor * 0.3f + assistants * 0.1f);
+        }
+
+        private void ApplyEducationSkillProgress(
+            Entity entity,
+            uint currentTick,
+            float learningOutput,
+            float trainingOutput,
+            float researchOutput,
+            in LeisureEducationPolicy policy,
+            bool hasSkillLog,
+            DynamicBuffer<SkillChangeLogEntry> skillLog)
+        {
+            if (!_xpLookup.HasComponent(entity) || !_skillsLookup.HasComponent(entity))
+            {
+                return;
+            }
+
+            var xp = _xpLookup[entity];
+            var skills = _skillsLookup[entity];
+            var gainScale = math.max(0f, policy.SkillGainScale);
+
+            var studyMagnitude = (learningOutput + researchOutput * 0.3f) * gainScale;
+            var drillMagnitude = trainingOutput * gainScale;
+
+            if (studyMagnitude > 1e-5f)
+            {
+                var explorationDelta = Space4XSkillUtility.ComputeDeltaXp(SkillDomain.Exploration, studyMagnitude);
+                var haulingDelta = Space4XSkillUtility.ComputeDeltaXp(SkillDomain.Hauling, studyMagnitude * 0.45f);
+                xp.ExplorationXp += explorationDelta;
+                xp.HaulingXp += haulingDelta;
+                if (hasSkillLog && skillLog.IsCreated)
+                {
+                    skillLog.Add(new SkillChangeLogEntry
+                    {
+                        Tick = currentTick,
+                        TargetEntity = entity,
+                        Domain = SkillDomain.Exploration,
+                        DeltaXp = explorationDelta,
+                        NewSkill = skills.ExplorationSkill
+                    });
+                    skillLog.Add(new SkillChangeLogEntry
+                    {
+                        Tick = currentTick,
+                        TargetEntity = entity,
+                        Domain = SkillDomain.Hauling,
+                        DeltaXp = haulingDelta,
+                        NewSkill = skills.HaulingSkill
+                    });
+                }
+            }
+
+            if (drillMagnitude > 1e-5f)
+            {
+                var combatDelta = Space4XSkillUtility.ComputeDeltaXp(SkillDomain.Combat, drillMagnitude);
+                var repairDelta = Space4XSkillUtility.ComputeDeltaXp(SkillDomain.Repair, drillMagnitude * 0.5f);
+                xp.CombatXp += combatDelta;
+                xp.RepairXp += repairDelta;
+                if (hasSkillLog && skillLog.IsCreated)
+                {
+                    skillLog.Add(new SkillChangeLogEntry
+                    {
+                        Tick = currentTick,
+                        TargetEntity = entity,
+                        Domain = SkillDomain.Combat,
+                        DeltaXp = combatDelta,
+                        NewSkill = skills.CombatSkill
+                    });
+                    skillLog.Add(new SkillChangeLogEntry
+                    {
+                        Tick = currentTick,
+                        TargetEntity = entity,
+                        Domain = SkillDomain.Repair,
+                        DeltaXp = repairDelta,
+                        NewSkill = skills.RepairSkill
+                    });
+                }
+            }
+
+            xp.LastProcessedTick = currentTick;
+            _xpLookup[entity] = xp;
+
+            skills.MiningSkill = Space4XSkillUtility.XpToSkill(xp.MiningXp);
+            skills.HaulingSkill = Space4XSkillUtility.XpToSkill(xp.HaulingXp);
+            skills.CombatSkill = Space4XSkillUtility.XpToSkill(xp.CombatXp);
+            skills.RepairSkill = Space4XSkillUtility.XpToSkill(xp.RepairXp);
+            skills.ExplorationSkill = Space4XSkillUtility.XpToSkill(xp.ExplorationXp);
+            _skillsLookup[entity] = skills;
+        }
+
+        private static void ApplyCrewWisdomGain(
+            Entity owner,
+            float wisdomOutput,
+            in LeisureEducationPolicy policy,
+            ref BufferLookup<PDCrewMember> crewLookup,
+            ref ComponentLookup<PureDOTS.Runtime.Stats.WisdomStat> wisdomLookup)
+        {
+            if (wisdomOutput <= 1e-5f || !crewLookup.HasBuffer(owner))
+            {
+                return;
+            }
+
+            var crew = crewLookup[owner];
+            if (crew.Length == 0)
+            {
+                return;
+            }
+
+            var perCrewGain = wisdomOutput * math.max(0f, policy.WisdomGainScale) * 100f / crew.Length;
+            if (perCrewGain <= 1e-5f)
+            {
+                return;
+            }
+
+            for (var i = 0; i < crew.Length; i++)
+            {
+                var crewEntity = crew[i].CrewEntity;
+                if (crewEntity == Entity.Null || !wisdomLookup.HasComponent(crewEntity))
+                {
+                    continue;
+                }
+
+                var wisdom = wisdomLookup[crewEntity];
+                wisdom.Wisdom = math.clamp(wisdom.Wisdom + perCrewGain, 0f, 100f);
+                wisdomLookup[crewEntity] = wisdom;
+            }
         }
 
         private static LeisureOpportunityType ResolveOpportunityType(
@@ -772,9 +1129,10 @@ namespace Space4X.Registry
             float poison,
             float assassin,
             float bribery,
+            float facultySubversion,
             float roll)
         {
-            var total = math.max(1e-5f, espionage + poison + assassin + bribery);
+            var total = math.max(1e-5f, espionage + poison + assassin + bribery + facultySubversion);
             var cursor = espionage / total;
             if (roll <= cursor)
             {
@@ -793,7 +1151,13 @@ namespace Space4X.Registry
                 return LeisureIncidentType.SleeperAssassin;
             }
 
-            return LeisureIncidentType.BriberyDemand;
+            cursor += bribery / total;
+            if (roll <= cursor)
+            {
+                return LeisureIncidentType.BriberyDemand;
+            }
+
+            return LeisureIncidentType.FacultySubversion;
         }
 
         private static Entity ResolveIncidentSourceModule(
@@ -801,7 +1165,8 @@ namespace Space4X.Registry
             Entity espionageModule,
             Entity poisonModule,
             Entity assassinModule,
-            Entity briberyModule)
+            Entity briberyModule,
+            Entity facultySubversionModule)
         {
             return type switch
             {
@@ -809,6 +1174,7 @@ namespace Space4X.Registry
                 LeisureIncidentType.PoisonedSupply => poisonModule,
                 LeisureIncidentType.SleeperAssassin => assassinModule,
                 LeisureIncidentType.BriberyDemand => briberyModule,
+                LeisureIncidentType.FacultySubversion => facultySubversionModule,
                 _ => Entity.Null
             };
         }

--- a/Assets/Scripts/Space4x/Registry/Space4XMoraleComponents.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XMoraleComponents.cs
@@ -72,7 +72,8 @@ namespace Space4X.Registry
         FamilyPresence = 14,
         SpeciesConflict = 15,
         Leisure = 16,
-        Espionage = 17
+        Espionage = 17,
+        Education = 18
     }
 
     /// <summary>

--- a/Assets/Scripts/Space4x/Registry/Space4XShipLoopBootstrapSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XShipLoopBootstrapSystem.cs
@@ -101,6 +101,16 @@ namespace Space4X.Registry
                 ecb.AddComponent<LeisureFacilityAggregate>(shipEntity);
             }
 
+            if (!em.HasComponent<LeisureEducationPolicy>(shipEntity))
+            {
+                ecb.AddComponent(shipEntity, LeisureEducationPolicy.Default);
+            }
+
+            if (!em.HasComponent<LeisureEducationProgress>(shipEntity))
+            {
+                ecb.AddComponent<LeisureEducationProgress>(shipEntity);
+            }
+
             if (!em.HasBuffer<LeisureIncidentEvent>(shipEntity))
             {
                 ecb.AddBuffer<LeisureIncidentEvent>(shipEntity);
@@ -109,6 +119,24 @@ namespace Space4X.Registry
             if (!em.HasBuffer<LeisureOpportunityEvent>(shipEntity))
             {
                 ecb.AddBuffer<LeisureOpportunityEvent>(shipEntity);
+            }
+
+            if (!em.HasComponent<CrewSkills>(shipEntity))
+            {
+                ecb.AddComponent(shipEntity, new CrewSkills());
+            }
+
+            if (!em.HasComponent<SkillExperienceGain>(shipEntity))
+            {
+                ecb.AddComponent(shipEntity, new SkillExperienceGain
+                {
+                    MiningXp = 0f,
+                    HaulingXp = 0f,
+                    CombatXp = 0f,
+                    RepairXp = 0f,
+                    ExplorationXp = 0f,
+                    LastProcessedTick = 0u
+                });
             }
         }
 

--- a/Assets/Scripts/Space4x/Registry/Space4XTaxComponents.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XTaxComponents.cs
@@ -1,0 +1,110 @@
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Space4X.Registry
+{
+    /// <summary>
+    /// Which profile should steer the effective tax rate.
+    /// </summary>
+    public enum Space4XTaxProfileSource : byte
+    {
+        Ruler = 0,
+        SocietyAverage = 1,
+        Blend = 2
+    }
+
+    /// <summary>
+    /// Configurable taxation policy for a faction.
+    /// </summary>
+    public struct Space4XTaxPolicy : IComponentData
+    {
+        public byte Enabled;
+        public uint CollectionIntervalTicks;
+        public Space4XTaxProfileSource ProfileSource;
+        public half SocietyBlendWeight01;
+
+        public half BaseRate01;
+        public half MinRate01;
+        public half MaxRate01;
+
+        public half LawfulnessRateWeight01;
+        public half IntegrityRateWeight01;
+
+        public half AuthoritarianRateBias01;
+        public half EgalitarianRateBias01;
+
+        public half BaseLeakRate01;
+        public half CorruptLeakBonus01;
+
+        public half BusinessAssetTaxRate01;
+        public float BusinessCreditsExemption;
+
+        public static Space4XTaxPolicy Default => new Space4XTaxPolicy
+        {
+            Enabled = 1,
+            CollectionIntervalTicks = 30u,
+            ProfileSource = Space4XTaxProfileSource.Blend,
+            SocietyBlendWeight01 = (half)0.5f,
+            BaseRate01 = (half)0.12f,
+            MinRate01 = (half)0.02f,
+            MaxRate01 = (half)0.55f,
+            LawfulnessRateWeight01 = (half)0.08f,
+            IntegrityRateWeight01 = (half)0.04f,
+            AuthoritarianRateBias01 = (half)0.03f,
+            EgalitarianRateBias01 = (half)(-0.02f),
+            BaseLeakRate01 = (half)0.01f,
+            CorruptLeakBonus01 = (half)0.08f,
+            BusinessAssetTaxRate01 = (half)0.05f,
+            BusinessCreditsExemption = 120f
+        };
+    }
+
+    /// <summary>
+    /// Progressive or regressive adjustment band applied by income bucket.
+    /// </summary>
+    [InternalBufferCapacity(4)]
+    public struct Space4XTaxBand : IBufferElementData
+    {
+        public float MinIncomePerTick;
+        public float MaxIncomePerTick;
+        public half RateOffset01;
+    }
+
+    /// <summary>
+    /// Optional per-entity income that can be taxed by an authority.
+    /// </summary>
+    public struct Space4XTaxableIncome : IComponentData
+    {
+        public Entity TaxAuthority;
+        public float GrossIncomePerTick;
+        public float ShieldIncomePerTick;
+        public byte IsExempt;
+        public byte WithholdFromWallet;
+    }
+
+    /// <summary>
+    /// Optional group/sub-group membership for nuanced tax offsets.
+    /// </summary>
+    public struct Space4XTaxBandMembership : IComponentData
+    {
+        public ushort BandId;
+        public ushort SubBandId;
+        public half RateOffset01;
+    }
+
+    /// <summary>
+    /// Runtime taxation snapshot per faction.
+    /// </summary>
+    public struct Space4XTaxRuntime : IComponentData
+    {
+        public uint LastCollectionTick;
+        public float LastCollectedCredits;
+        public float LastLeakageCredits;
+        public float LastEffectiveRate01;
+        public float LastProfileLaw;
+        public float LastProfileIntegrity;
+        public uint LastTaxpayerCount;
+        public float TotalCollectedCredits;
+        public float TotalLeakageCredits;
+    }
+}

--- a/Assets/Scripts/Space4x/Registry/Space4XTaxSystem.cs
+++ b/Assets/Scripts/Space4x/Registry/Space4XTaxSystem.cs
@@ -1,0 +1,509 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Space4X.Registry
+{
+    /// <summary>
+    /// Ensures factions have default taxation policy data.
+    /// </summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(Space4XTaxCollectionSystem))]
+    public partial struct Space4XTaxBootstrapSystem : ISystem
+    {
+        [BurstCompile]
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<FactionResources>();
+            state.RequireForUpdate<Space4XFaction>();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            var em = state.EntityManager;
+
+            foreach (var (_, entity) in SystemAPI.Query<RefRO<Space4XFaction>>()
+                         .WithAll<FactionResources>()
+                         .WithEntityAccess())
+            {
+                if (!em.HasComponent<Space4XTaxPolicy>(entity))
+                {
+                    ecb.AddComponent(entity, Space4XTaxPolicy.Default);
+                }
+
+                if (!em.HasComponent<Space4XTaxRuntime>(entity))
+                {
+                    ecb.AddComponent(entity, new Space4XTaxRuntime
+                    {
+                        LastCollectionTick = 0u,
+                        LastCollectedCredits = 0f,
+                        LastLeakageCredits = 0f,
+                        LastEffectiveRate01 = 0f,
+                        LastProfileLaw = 0f,
+                        LastProfileIntegrity = 0f,
+                        LastTaxpayerCount = 0u,
+                        TotalCollectedCredits = 0f,
+                        TotalLeakageCredits = 0f
+                    });
+                }
+
+                if (!em.HasBuffer<Space4XTaxBand>(entity))
+                {
+                    var bands = ecb.AddBuffer<Space4XTaxBand>(entity);
+                    bands.Add(new Space4XTaxBand { MinIncomePerTick = 0f, MaxIncomePerTick = 4f, RateOffset01 = (half)(-0.03f) });
+                    bands.Add(new Space4XTaxBand { MinIncomePerTick = 4f, MaxIncomePerTick = 16f, RateOffset01 = (half)0f });
+                    bands.Add(new Space4XTaxBand { MinIncomePerTick = 16f, MaxIncomePerTick = 64f, RateOffset01 = (half)0.03f });
+                    bands.Add(new Space4XTaxBand { MinIncomePerTick = 64f, MaxIncomePerTick = 0f, RateOffset01 = (half)0.06f });
+                }
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Collects taxes into faction treasuries using policy bands and profile-influenced rates.
+    /// </summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(Space4XFactionEconomySystem))]
+    public partial struct Space4XTaxCollectionSystem : ISystem
+    {
+        private struct TaxpayerRecord
+        {
+            public Entity Taxpayer;
+            public float GrossIncomePerTick;
+            public float ShieldIncomePerTick;
+            public float MembershipRateOffset;
+            public byte WithholdFromWallet;
+        }
+
+        private ComponentLookup<AlignmentTriplet> _alignmentLookup;
+        private ComponentLookup<Space4XFaction> _factionLookup;
+        private ComponentLookup<Space4XBusinessState> _businessLookup;
+        private ComponentLookup<Space4XTaxBandMembership> _membershipLookup;
+        private BufferLookup<AffiliationTag> _affiliationLookup;
+        private EntityStorageInfoLookup _entityLookup;
+
+        [BurstCompile]
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<FactionResources>();
+            state.RequireForUpdate<Space4XFaction>();
+            state.RequireForUpdate<Space4XTaxPolicy>();
+
+            _alignmentLookup = state.GetComponentLookup<AlignmentTriplet>(true);
+            _factionLookup = state.GetComponentLookup<Space4XFaction>(true);
+            _businessLookup = state.GetComponentLookup<Space4XBusinessState>(false);
+            _membershipLookup = state.GetComponentLookup<Space4XTaxBandMembership>(true);
+            _affiliationLookup = state.GetBufferLookup<AffiliationTag>(true);
+            _entityLookup = state.GetEntityStorageInfoLookup();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            _alignmentLookup.Update(ref state);
+            _factionLookup.Update(ref state);
+            _businessLookup.Update(ref state);
+            _membershipLookup.Update(ref state);
+            _affiliationLookup.Update(ref state);
+            _entityLookup.Update(ref state);
+
+            var tick = (uint)SystemAPI.Time.ElapsedTime;
+
+            var societySums = new NativeParallelHashMap<Entity, float2>(256, Allocator.Temp);
+            var societyCounts = new NativeParallelHashMap<Entity, int>(256, Allocator.Temp);
+            var businessesByAuthority = new NativeParallelMultiHashMap<Entity, Entity>(8192, Allocator.Temp);
+            var taxpayersByAuthority = new NativeParallelMultiHashMap<Entity, TaxpayerRecord>(8192, Allocator.Temp);
+
+            foreach (var (alignment, affiliations) in SystemAPI.Query<RefRO<AlignmentTriplet>, DynamicBuffer<AffiliationTag>>())
+            {
+                var law = (float)alignment.ValueRO.Law;
+                var integrity = (float)alignment.ValueRO.Integrity;
+                var affiliationBuffer = affiliations;
+                for (int i = 0; i < affiliationBuffer.Length; i++)
+                {
+                    var affiliation = affiliationBuffer[i];
+                    if (affiliation.Type != AffiliationType.Faction ||
+                        !IsFactionEntity(affiliation.Target))
+                    {
+                        continue;
+                    }
+
+                    if (societySums.TryGetValue(affiliation.Target, out var existing))
+                    {
+                        societySums[affiliation.Target] = existing + new float2(law, integrity);
+                        societyCounts[affiliation.Target] = societyCounts[affiliation.Target] + 1;
+                    }
+                    else
+                    {
+                        societySums.TryAdd(affiliation.Target, new float2(law, integrity));
+                        societyCounts.TryAdd(affiliation.Target, 1);
+                    }
+                }
+            }
+
+            foreach (var (business, businessEntity) in SystemAPI.Query<RefRO<Space4XBusinessState>>().WithEntityAccess())
+            {
+                var authority = ResolveTaxAuthority(business.ValueRO.Owner, business.ValueRO.Colony);
+                if (authority != Entity.Null)
+                {
+                    businessesByAuthority.Add(authority, businessEntity);
+                }
+            }
+
+            foreach (var (taxable, entity) in SystemAPI.Query<RefRO<Space4XTaxableIncome>>().WithEntityAccess())
+            {
+                var data = taxable.ValueRO;
+                if (data.IsExempt != 0 ||
+                    data.TaxAuthority == Entity.Null ||
+                    !IsFactionEntity(data.TaxAuthority))
+                {
+                    continue;
+                }
+
+                var memberOffset = 0f;
+                if (_membershipLookup.HasComponent(entity))
+                {
+                    memberOffset = (float)_membershipLookup[entity].RateOffset01;
+                }
+
+                taxpayersByAuthority.Add(data.TaxAuthority, new TaxpayerRecord
+                {
+                    Taxpayer = entity,
+                    GrossIncomePerTick = data.GrossIncomePerTick,
+                    ShieldIncomePerTick = data.ShieldIncomePerTick,
+                    MembershipRateOffset = memberOffset,
+                    WithholdFromWallet = data.WithholdFromWallet
+                });
+            }
+
+            foreach (var (resources, faction, policy, runtime, bands, factionEntity) in
+                     SystemAPI.Query<RefRW<FactionResources>, RefRO<Space4XFaction>, RefRO<Space4XTaxPolicy>, RefRW<Space4XTaxRuntime>, DynamicBuffer<Space4XTaxBand>>()
+                         .WithEntityAccess())
+            {
+                var policyData = policy.ValueRO;
+                if (policyData.Enabled == 0)
+                {
+                    continue;
+                }
+
+                var interval = math.max(1u, policyData.CollectionIntervalTicks);
+                if (runtime.ValueRO.LastCollectionTick > 0u)
+                {
+                    var elapsed = tick - runtime.ValueRO.LastCollectionTick;
+                    if (elapsed < interval)
+                    {
+                        continue;
+                    }
+                }
+
+                var elapsedTicks = runtime.ValueRO.LastCollectionTick == 0u
+                    ? interval
+                    : math.max(1u, tick - runtime.ValueRO.LastCollectionTick);
+
+                var rulerProfile = ResolveRulerProfile(factionEntity, faction.ValueRO);
+                var societyProfile = rulerProfile;
+                if (societySums.TryGetValue(factionEntity, out var societySum) &&
+                    societyCounts.TryGetValue(factionEntity, out var societyCount) &&
+                    societyCount > 0)
+                {
+                    var invCount = 1f / societyCount;
+                    societyProfile = societySum * invCount;
+                }
+
+                var blendWeight = math.saturate((float)policyData.SocietyBlendWeight01);
+                var selectedProfile = policyData.ProfileSource switch
+                {
+                    Space4XTaxProfileSource.Ruler => rulerProfile,
+                    Space4XTaxProfileSource.SocietyAverage => societyProfile,
+                    _ => math.lerp(rulerProfile, societyProfile, blendWeight)
+                };
+
+                var baseRate = (float)policyData.BaseRate01 +
+                               selectedProfile.x * (float)policyData.LawfulnessRateWeight01 +
+                               selectedProfile.y * (float)policyData.IntegrityRateWeight01 +
+                               ResolveOutlookRateBias(faction.ValueRO.Outlook, policyData);
+                baseRate = math.clamp(baseRate, (float)policyData.MinRate01, (float)policyData.MaxRate01);
+
+                var collectedGross = 0f;
+                var taxpayerCount = 0u;
+
+                if (taxpayersByAuthority.TryGetFirstValue(factionEntity, out var taxpayer, out var taxpayerIterator))
+                {
+                    do
+                    {
+                        var taxablePerTick = math.max(0f, taxpayer.GrossIncomePerTick - taxpayer.ShieldIncomePerTick);
+                        if (taxablePerTick <= 0f)
+                        {
+                            continue;
+                        }
+
+                        var rate = ResolveBandRate(
+                            baseRate,
+                            taxablePerTick,
+                            taxpayer.MembershipRateOffset,
+                            bands,
+                            policyData.MinRate01,
+                            policyData.MaxRate01);
+
+                        var due = taxablePerTick * elapsedTicks * rate;
+                        if (due <= 0f)
+                        {
+                            continue;
+                        }
+
+                        var paid = due;
+                        if (taxpayer.WithholdFromWallet != 0)
+                        {
+                            paid = TryWithholdFromBusinessWallet(taxpayer.Taxpayer, due);
+                        }
+
+                        if (paid > 0f)
+                        {
+                            collectedGross += paid;
+                            taxpayerCount++;
+                        }
+                    }
+                    while (taxpayersByAuthority.TryGetNextValue(out taxpayer, ref taxpayerIterator));
+                }
+
+                if ((float)policyData.BusinessAssetTaxRate01 > 0f &&
+                    businessesByAuthority.TryGetFirstValue(factionEntity, out var businessEntity, out var businessIterator))
+                {
+                    do
+                    {
+                        if (!_businessLookup.HasComponent(businessEntity))
+                        {
+                            continue;
+                        }
+
+                        var business = _businessLookup[businessEntity];
+                        var taxableCredits = math.max(0f, business.Credits - policyData.BusinessCreditsExemption);
+                        if (taxableCredits <= 0f)
+                        {
+                            continue;
+                        }
+
+                        var perTickBasis = taxableCredits / math.max(1f, elapsedTicks);
+                        var rate = ResolveBandRate(
+                            baseRate + (float)policyData.BusinessAssetTaxRate01,
+                            perTickBasis,
+                            0f,
+                            bands,
+                            policyData.MinRate01,
+                            policyData.MaxRate01);
+
+                        var due = taxableCredits * rate;
+                        var paid = math.min(math.max(0f, business.Credits), due);
+                        if (paid <= 0f)
+                        {
+                            continue;
+                        }
+
+                        business.Credits = math.max(0f, business.Credits - paid);
+                        _businessLookup[businessEntity] = business;
+
+                        collectedGross += paid;
+                        taxpayerCount++;
+                    }
+                    while (businessesByAuthority.TryGetNextValue(out businessEntity, ref businessIterator));
+                }
+
+                var leakRate = ResolveLeakRate(faction.ValueRO.Outlook, selectedProfile.y, policyData);
+                var leakage = collectedGross * leakRate;
+                var collectedNet = math.max(0f, collectedGross - leakage);
+
+                resources.ValueRW.Credits = math.max(0f, resources.ValueRO.Credits + collectedNet);
+
+                runtime.ValueRW.LastCollectionTick = tick;
+                runtime.ValueRW.LastCollectedCredits = collectedGross;
+                runtime.ValueRW.LastLeakageCredits = leakage;
+                runtime.ValueRW.LastEffectiveRate01 = baseRate;
+                runtime.ValueRW.LastProfileLaw = selectedProfile.x;
+                runtime.ValueRW.LastProfileIntegrity = selectedProfile.y;
+                runtime.ValueRW.LastTaxpayerCount = taxpayerCount;
+                runtime.ValueRW.TotalCollectedCredits += collectedGross;
+                runtime.ValueRW.TotalLeakageCredits += leakage;
+            }
+
+            societySums.Dispose();
+            societyCounts.Dispose();
+            businessesByAuthority.Dispose();
+            taxpayersByAuthority.Dispose();
+        }
+
+        private bool IsFactionEntity(Entity entity)
+        {
+            return entity != Entity.Null &&
+                   _entityLookup.Exists(entity) &&
+                   _factionLookup.HasComponent(entity);
+        }
+
+        private Entity ResolveTaxAuthority(Entity owner, Entity colony)
+        {
+            if (IsFactionEntity(owner))
+            {
+                return owner;
+            }
+
+            if (colony == Entity.Null ||
+                !_entityLookup.Exists(colony) ||
+                !_affiliationLookup.HasBuffer(colony))
+            {
+                return Entity.Null;
+            }
+
+            var affiliations = _affiliationLookup[colony];
+            for (int i = 0; i < affiliations.Length; i++)
+            {
+                var affiliation = affiliations[i];
+                if (affiliation.Type == AffiliationType.Faction && IsFactionEntity(affiliation.Target))
+                {
+                    return affiliation.Target;
+                }
+            }
+
+            return Entity.Null;
+        }
+
+        private float2 ResolveRulerProfile(Entity factionEntity, Space4XFaction faction)
+        {
+            if (_alignmentLookup.HasComponent(factionEntity))
+            {
+                var alignment = _alignmentLookup[factionEntity];
+                return new float2((float)alignment.Law, (float)alignment.Integrity);
+            }
+
+            var law = 0f;
+            var integrity = 0f;
+
+            if ((faction.Outlook & FactionOutlook.Authoritarian) != 0)
+            {
+                law += 0.6f;
+            }
+
+            if ((faction.Outlook & FactionOutlook.Egalitarian) != 0)
+            {
+                law -= 0.2f;
+            }
+
+            if ((faction.Outlook & FactionOutlook.Honorable) != 0)
+            {
+                integrity += 0.6f;
+            }
+
+            if ((faction.Outlook & FactionOutlook.Corrupt) != 0)
+            {
+                integrity -= 0.7f;
+            }
+
+            if ((faction.Outlook & FactionOutlook.Spiritualist) != 0)
+            {
+                integrity += 0.1f;
+            }
+
+            return math.clamp(new float2(law, integrity), new float2(-1f, -1f), new float2(1f, 1f));
+        }
+
+        private static float ResolveOutlookRateBias(FactionOutlook outlook, Space4XTaxPolicy policy)
+        {
+            var bias = 0f;
+            if ((outlook & FactionOutlook.Authoritarian) != 0)
+            {
+                bias += (float)policy.AuthoritarianRateBias01;
+            }
+
+            if ((outlook & FactionOutlook.Egalitarian) != 0)
+            {
+                bias += (float)policy.EgalitarianRateBias01;
+            }
+
+            return bias;
+        }
+
+        private static float ResolveLeakRate(FactionOutlook outlook, float profileIntegrity, Space4XTaxPolicy policy)
+        {
+            var leak = (float)policy.BaseLeakRate01;
+            if ((outlook & FactionOutlook.Corrupt) != 0)
+            {
+                leak += (float)policy.CorruptLeakBonus01;
+            }
+
+            if (profileIntegrity < 0f)
+            {
+                leak += math.abs(profileIntegrity) * 0.05f;
+            }
+
+            return math.clamp(leak, 0f, 0.9f);
+        }
+
+        private float TryWithholdFromBusinessWallet(Entity taxpayer, float due)
+        {
+            if (due <= 0f || !_businessLookup.HasComponent(taxpayer))
+            {
+                return 0f;
+            }
+
+            var business = _businessLookup[taxpayer];
+            var paid = math.min(math.max(0f, business.Credits), due);
+            if (paid <= 0f)
+            {
+                return 0f;
+            }
+
+            business.Credits = math.max(0f, business.Credits - paid);
+            _businessLookup[taxpayer] = business;
+            return paid;
+        }
+
+        private static float ResolveBandRate(
+            float baseRate,
+            float incomePerTick,
+            float extraOffset,
+            DynamicBuffer<Space4XTaxBand> bands,
+            half minRate,
+            half maxRate)
+        {
+            var bandOffset = ResolveBandOffset(incomePerTick, bands);
+            var raw = baseRate + bandOffset + extraOffset;
+            return math.clamp(raw, (float)minRate, (float)maxRate);
+        }
+
+        private static float ResolveBandOffset(float incomePerTick, DynamicBuffer<Space4XTaxBand> bands)
+        {
+            if (bands.Length == 0)
+            {
+                return 0f;
+            }
+
+            var fallback = (float)bands[0].RateOffset01;
+            var hasFallback = false;
+
+            for (int i = 0; i < bands.Length; i++)
+            {
+                var band = bands[i];
+                var inLower = incomePerTick >= band.MinIncomePerTick;
+                var inUpper = band.MaxIncomePerTick <= 0f || incomePerTick < band.MaxIncomePerTick;
+                if (inLower && inUpper)
+                {
+                    return (float)band.RateOffset01;
+                }
+
+                if (incomePerTick >= band.MinIncomePerTick)
+                {
+                    fallback = (float)band.RateOffset01;
+                    hasFallback = true;
+                }
+            }
+
+            return hasFallback ? fallback : (float)bands[0].RateOffset01;
+        }
+    }
+}

--- a/Assets/Scripts/Space4x/Tests/Space4XLeisureSystemTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XLeisureSystemTests.cs
@@ -9,6 +9,7 @@ namespace Space4X.Tests
     using PDCarrierModuleSlot = PureDOTS.Runtime.Ships.CarrierModuleSlot;
     using PDShipModule = PureDOTS.Runtime.Ships.ShipModule;
     using PDCrewMember = PureDOTS.Runtime.Platform.PlatformCrewMember;
+    using WisdomStat = PureDOTS.Runtime.Stats.WisdomStat;
 
     public class Space4XLeisureSystemTests
     {
@@ -350,6 +351,170 @@ namespace Space4X.Tests
             Assert.Greater((float)after.Integrity, (float)before.Integrity);
         }
 
+        [Test]
+        public void EducationFacility_UsesScheduleAndRaisesSkillsAndWisdom()
+        {
+            var ship = CreateShipBase();
+            _entityManager.SetComponentData(ship, new CrewCapacity
+            {
+                MaxCrew = 60,
+                CurrentCrew = 20,
+                CriticalMax = 90
+            });
+
+            _entityManager.SetComponentData(ship, new LeisureEducationPolicy
+            {
+                Enabled = 1,
+                DayLengthHours = 24f,
+                SchoolStartHour = 8f,
+                SchoolDurationHours = 4f,
+                UniversityShiftAStartHour = 8f,
+                UniversityShiftBStartHour = 14f,
+                UniversityShiftDurationHours = 4f,
+                TrainingStartHour = 18f,
+                TrainingDurationHours = 2f,
+                OffHoursEfficiency = (half)0.05f,
+                EnrollmentRatio = (half)0.7f,
+                TutorQuality01 = (half)0.9f,
+                ProfessorQuality01 = (half)0.85f,
+                AssistantCoverage01 = (half)0.75f,
+                Standards01 = (half)0.8f,
+                IdeologyResistance01 = (half)0.6f,
+                BriberyOversight01 = (half)0.6f,
+                SkillGainScale = 3f,
+                WisdomGainScale = 1f,
+                ResearchScale = 1f
+            });
+
+            var crew = _entityManager.AddBuffer<PDCrewMember>(ship);
+            var student = _entityManager.CreateEntity(typeof(WisdomStat));
+            _entityManager.SetComponentData(student, WisdomStat.FromValue(30f));
+            crew.Add(new PDCrewMember { CrewEntity = student, RoleId = 0 });
+
+            var module = _entityManager.CreateEntity(typeof(PDShipModule), typeof(LeisureFacilityLimb));
+            _entityManager.SetComponentData(module, new LeisureFacilityLimb
+            {
+                Type = LeisureFacilityType.School,
+                HousingCapacity = 0f,
+                EducationRate = 0.5f,
+                TrainingRate = 0.12f,
+                WisdomRate = 0.3f,
+                ResearchRate = 0.2f,
+                IdeologyPressure = 0.05f,
+                FacultyBriberyRisk = 0.05f
+            });
+            var slots = _entityManager.AddBuffer<PDCarrierModuleSlot>(ship);
+            slots.Add(new PDCarrierModuleSlot { InstalledModule = module });
+
+            var xpBefore = _entityManager.GetComponentData<SkillExperienceGain>(ship);
+            var wisdomBefore = _entityManager.GetComponentData<WisdomStat>(student);
+
+            SetTick(9u); // Hour 9 is inside school window.
+            var system = _world.GetOrCreateSystem<Space4XLeisureNeedSystem>();
+            system.Update(_world.Unmanaged);
+
+            var xpAfter = _entityManager.GetComponentData<SkillExperienceGain>(ship);
+            var skillsAfter = _entityManager.GetComponentData<CrewSkills>(ship);
+            var wisdomAfter = _entityManager.GetComponentData<WisdomStat>(student);
+            var aggregate = _entityManager.GetComponentData<LeisureFacilityAggregate>(ship);
+
+            Assert.Greater(xpAfter.ExplorationXp, xpBefore.ExplorationXp, "Schooling should add exploration XP.");
+            Assert.Greater(xpAfter.CombatXp, xpBefore.CombatXp, "Training output should add combat XP.");
+            Assert.Greater(skillsAfter.ExplorationSkill, 0f, "Learning should convert to non-zero skill.");
+            Assert.Greater(wisdomAfter.Wisdom, wisdomBefore.Wisdom, "Scheduled learning should increase crew wisdom.");
+            Assert.Greater(aggregate.EducationRate, 0f);
+            Assert.Greater(aggregate.WisdomRate, 0f);
+
+            var modifiers = _entityManager.GetBuffer<MoraleModifier>(ship);
+            Assert.IsTrue(TryGetModifier(modifiers, MoraleModifierSource.Education, out var educationMod));
+            Assert.Greater((float)educationMod.Strength, -0.2f, "Education modifier should exist and not collapse morale in a healthy school setup.");
+        }
+
+        [Test]
+        public void UniversityFacultyBriberyRisk_CanEmitFacultySubversionIncident()
+        {
+            var ship = CreateShipBase();
+            _entityManager.SetComponentData(ship, new CrewCapacity
+            {
+                MaxCrew = 80,
+                CurrentCrew = 30,
+                CriticalMax = 120
+            });
+            _entityManager.SetComponentData(ship, AlignmentTriplet.FromFloats(-0.6f, -0.8f, -0.9f));
+            _entityManager.SetComponentData(ship, new LeisureSecurityPolicy
+            {
+                CounterIntelLevel = (half)0f,
+                FoodSafetyLevel = (half)0f,
+                InternalSecurityLevel = (half)0f,
+                BriberyBudget = (half)0f
+            });
+            _entityManager.SetComponentData(ship, new LeisureEducationPolicy
+            {
+                Enabled = 1,
+                DayLengthHours = 24f,
+                SchoolStartHour = 8f,
+                SchoolDurationHours = 3f,
+                UniversityShiftAStartHour = 8f,
+                UniversityShiftBStartHour = 14f,
+                UniversityShiftDurationHours = 4f,
+                TrainingStartHour = 18f,
+                TrainingDurationHours = 2f,
+                OffHoursEfficiency = (half)0.25f,
+                EnrollmentRatio = (half)0.6f,
+                TutorQuality01 = (half)0.6f,
+                ProfessorQuality01 = (half)0.7f,
+                AssistantCoverage01 = (half)0.5f,
+                Standards01 = (half)0.6f,
+                IdeologyResistance01 = (half)0f,
+                BriberyOversight01 = (half)0f,
+                SkillGainScale = 1f,
+                WisdomGainScale = 0.5f,
+                ResearchScale = 1f
+            });
+
+            var module = _entityManager.CreateEntity(typeof(PDShipModule), typeof(LeisureFacilityLimb));
+            _entityManager.SetComponentData(module, new LeisureFacilityLimb
+            {
+                Type = LeisureFacilityType.University,
+                EducationRate = 0.2f,
+                WisdomRate = 0.1f,
+                ResearchRate = 0.35f,
+                IdeologyPressure = 0.5f,
+                FacultyBriberyRisk = 1f,
+                EspionageRisk = 0f,
+                PoisonRisk = 0f,
+                AssassinationRisk = 0f,
+                BriberyPressure = 0f
+            });
+            var slots = _entityManager.AddBuffer<PDCarrierModuleSlot>(ship);
+            slots.Add(new PDCarrierModuleSlot { InstalledModule = module });
+
+            var system = _world.GetOrCreateSystem<Space4XLeisureNeedSystem>();
+            var foundFacultyIncident = false;
+            for (uint tick = 1u; tick <= 720u; tick++)
+            {
+                SetTick(tick);
+                system.Update(_world.Unmanaged);
+
+                var incidents = _entityManager.GetBuffer<LeisureIncidentEvent>(ship);
+                for (var i = 0; i < incidents.Length; i++)
+                {
+                    if (incidents[i].Type == LeisureIncidentType.FacultySubversion)
+                    {
+                        foundFacultyIncident = true;
+                        break;
+                    }
+                }
+
+                if (foundFacultyIncident)
+                {
+                    break;
+                }
+            }
+
+            Assert.IsTrue(foundFacultyIncident, "High faculty bribery risk should eventually emit FacultySubversion incidents.");
+        }
+
         private Entity CreateShipBase()
         {
             var ship = _entityManager.CreateEntity(
@@ -357,17 +522,39 @@ namespace Space4X.Tests
                 typeof(LeisureNeedState),
                 typeof(LeisurePreferenceProfile),
                 typeof(LeisureSecurityPolicy),
-                typeof(LeisureFacilityAggregate));
+                typeof(LeisureFacilityAggregate),
+                typeof(LeisureEducationPolicy),
+                typeof(LeisureEducationProgress),
+                typeof(CrewSkills),
+                typeof(SkillExperienceGain));
 
             _entityManager.SetComponentData(ship, MoraleState.FromBaseline(0f));
             _entityManager.SetComponentData(ship, LeisureNeedState.Default);
             _entityManager.SetComponentData(ship, LeisurePreferenceProfile.Neutral);
             _entityManager.SetComponentData(ship, LeisureSecurityPolicy.Default);
+            _entityManager.SetComponentData(ship, LeisureEducationPolicy.Default);
             _entityManager.SetComponentData(ship, default(LeisureFacilityAggregate));
+            _entityManager.SetComponentData(ship, default(LeisureEducationProgress));
+            _entityManager.SetComponentData(ship, new CrewSkills());
+            _entityManager.SetComponentData(ship, new SkillExperienceGain());
             _entityManager.AddBuffer<MoraleModifier>(ship);
             _entityManager.AddBuffer<LeisureIncidentEvent>(ship);
             _entityManager.AddBuffer<LeisureOpportunityEvent>(ship);
             return ship;
+        }
+
+        private void SetTick(uint tick)
+        {
+            using var query = _entityManager.CreateEntityQuery(typeof(PureDOTS.Runtime.Components.TimeState));
+            var timeEntity = query.GetSingletonEntity();
+            var time = _entityManager.GetComponentData<PureDOTS.Runtime.Components.TimeState>(timeEntity);
+            time.Tick = tick;
+            time.IsPaused = false;
+            if (time.FixedDeltaTime <= 0f)
+            {
+                time.FixedDeltaTime = 1f;
+            }
+            _entityManager.SetComponentData(timeEntity, time);
         }
 
         private static bool TryGetModifier(DynamicBuffer<MoraleModifier> modifiers, MoraleModifierSource source, out MoraleModifier modifier)

--- a/Assets/Scripts/Space4x/Tests/Space4XTaxSystemsTests.cs
+++ b/Assets/Scripts/Space4x/Tests/Space4XTaxSystemsTests.cs
@@ -1,0 +1,252 @@
+#if UNITY_EDITOR || UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+using Space4X.Registry;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace Space4X.Tests
+{
+    public class Space4XTaxSystemsTests
+    {
+        private World _world;
+        private EntityManager _entityManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _world = new World("Space4XTaxSystemsTests");
+            _entityManager = _world.EntityManager;
+            CoreSingletonBootstrapSystem.EnsureSingletons(_entityManager);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_world.IsCreated)
+            {
+                _world.Dispose();
+            }
+        }
+
+        [Test]
+        public void TaxBootstrap_AddsDefaultPolicyRuntimeAndBands()
+        {
+            var faction = CreateFaction(11, FactionOutlook.Authoritarian);
+
+            var bootstrap = _world.GetOrCreateSystem<Space4XTaxBootstrapSystem>();
+            bootstrap.Update(_world.Unmanaged);
+
+            Assert.IsTrue(_entityManager.HasComponent<Space4XTaxPolicy>(faction));
+            Assert.IsTrue(_entityManager.HasComponent<Space4XTaxRuntime>(faction));
+            Assert.IsTrue(_entityManager.HasBuffer<Space4XTaxBand>(faction));
+
+            var bands = _entityManager.GetBuffer<Space4XTaxBand>(faction);
+            Assert.GreaterOrEqual(bands.Length, 3);
+        }
+
+        [Test]
+        public void TaxCollection_CollectsFromTaxableIncome_AndWithholdsBusinessWallet()
+        {
+            var faction = CreateFaction(12, FactionOutlook.None, startingCredits:0f);
+            ConfigurePolicy(faction, Space4XTaxProfileSource.Ruler, baseRate:0.2f, lawWeight:0f, integrityWeight:0f, businessAssetRate:0f);
+
+            var business = _entityManager.CreateEntity(typeof(Space4XBusinessState), typeof(Space4XTaxableIncome));
+            _entityManager.SetComponentData(business, new Space4XBusinessState
+            {
+                Kind = Space4XBusinessKind.MiningCompany,
+                OwnerKind = Space4XBusinessOwnerKind.Faction,
+                Owner = faction,
+                Colony = Entity.Null,
+                Facility = Entity.Null,
+                FacilityClass = FacilityBusinessClass.None,
+                ActiveJobId = default,
+                LastJobTick = 0u,
+                NextJobTick = 0u,
+                Credits = 100f
+            });
+            _entityManager.SetComponentData(business, new Space4XTaxableIncome
+            {
+                TaxAuthority = faction,
+                GrossIncomePerTick = 20f,
+                ShieldIncomePerTick = 5f,
+                IsExempt = 0,
+                WithholdFromWallet = 1
+            });
+
+            var taxSystem = _world.GetOrCreateSystem<Space4XTaxCollectionSystem>();
+            taxSystem.Update(_world.Unmanaged);
+
+            var businessAfter = _entityManager.GetComponentData<Space4XBusinessState>(business);
+            var factionAfter = _entityManager.GetComponentData<FactionResources>(faction);
+            var runtime = _entityManager.GetComponentData<Space4XTaxRuntime>(faction);
+
+            Assert.AreEqual(97f, businessAfter.Credits, 1e-3f);
+            Assert.AreEqual(3f, factionAfter.Credits, 1e-3f);
+            Assert.AreEqual(3f, runtime.LastCollectedCredits, 1e-3f);
+            Assert.AreEqual(1u, runtime.LastTaxpayerCount);
+        }
+
+        [Test]
+        public void TaxCollection_ProfileSourceChangesEffectiveRate()
+        {
+            var rulerFaction = CreateFaction(21, FactionOutlook.None, startingCredits:0f);
+            var societyFaction = CreateFaction(22, FactionOutlook.None, startingCredits:0f);
+
+            _entityManager.AddComponentData(rulerFaction, AlignmentTriplet.FromFloats(1f, 0f, 0f));
+            _entityManager.AddComponentData(societyFaction, AlignmentTriplet.FromFloats(1f, 0f, 0f));
+
+            ConfigurePolicy(rulerFaction, Space4XTaxProfileSource.Ruler, baseRate:0.1f, lawWeight:0.1f, integrityWeight:0f, businessAssetRate:0f);
+            ConfigurePolicy(societyFaction, Space4XTaxProfileSource.SocietyAverage, baseRate:0.1f, lawWeight:0.1f, integrityWeight:0f, businessAssetRate:0f);
+
+            var citizen = _entityManager.CreateEntity(typeof(AlignmentTriplet));
+            _entityManager.SetComponentData(citizen, AlignmentTriplet.FromFloats(-1f, 0f, 0f));
+            var affiliations = _entityManager.AddBuffer<AffiliationTag>(citizen);
+            affiliations.Add(new AffiliationTag
+            {
+                Type = AffiliationType.Faction,
+                Target = societyFaction,
+                Loyalty = (half)1f
+            });
+
+            var rulerTaxpayer = _entityManager.CreateEntity(typeof(Space4XTaxableIncome));
+            _entityManager.SetComponentData(rulerTaxpayer, new Space4XTaxableIncome
+            {
+                TaxAuthority = rulerFaction,
+                GrossIncomePerTick = 10f,
+                ShieldIncomePerTick = 0f,
+                IsExempt = 0,
+                WithholdFromWallet = 0
+            });
+
+            var societyTaxpayer = _entityManager.CreateEntity(typeof(Space4XTaxableIncome));
+            _entityManager.SetComponentData(societyTaxpayer, new Space4XTaxableIncome
+            {
+                TaxAuthority = societyFaction,
+                GrossIncomePerTick = 10f,
+                ShieldIncomePerTick = 0f,
+                IsExempt = 0,
+                WithholdFromWallet = 0
+            });
+
+            var taxSystem = _world.GetOrCreateSystem<Space4XTaxCollectionSystem>();
+            taxSystem.Update(_world.Unmanaged);
+
+            var rulerRuntime = _entityManager.GetComponentData<Space4XTaxRuntime>(rulerFaction);
+            var societyRuntime = _entityManager.GetComponentData<Space4XTaxRuntime>(societyFaction);
+
+            Assert.Greater(rulerRuntime.LastEffectiveRate01, societyRuntime.LastEffectiveRate01);
+            Assert.Greater(_entityManager.GetComponentData<FactionResources>(rulerFaction).Credits,
+                _entityManager.GetComponentData<FactionResources>(societyFaction).Credits);
+        }
+
+        [Test]
+        public void TaxCollection_BusinessAssetTaxUsesColonyFactionAffiliation()
+        {
+            var faction = CreateFaction(31, FactionOutlook.None, startingCredits:0f);
+            ConfigurePolicy(faction, Space4XTaxProfileSource.Ruler, baseRate:0f, lawWeight:0f, integrityWeight:0f, businessAssetRate:0.1f, exemption:50f);
+
+            var colony = _entityManager.CreateEntity();
+            var affiliations = _entityManager.AddBuffer<AffiliationTag>(colony);
+            affiliations.Add(new AffiliationTag
+            {
+                Type = AffiliationType.Faction,
+                Target = faction,
+                Loyalty = (half)1f
+            });
+
+            var business = _entityManager.CreateEntity(typeof(Space4XBusinessState));
+            _entityManager.SetComponentData(business, new Space4XBusinessState
+            {
+                Kind = Space4XBusinessKind.StationServices,
+                OwnerKind = Space4XBusinessOwnerKind.Individual,
+                Owner = Entity.Null,
+                Colony = colony,
+                Facility = Entity.Null,
+                FacilityClass = FacilityBusinessClass.None,
+                ActiveJobId = default,
+                LastJobTick = 0u,
+                NextJobTick = 0u,
+                Credits = 100f
+            });
+
+            var taxSystem = _world.GetOrCreateSystem<Space4XTaxCollectionSystem>();
+            taxSystem.Update(_world.Unmanaged);
+
+            var businessAfter = _entityManager.GetComponentData<Space4XBusinessState>(business);
+            var factionAfter = _entityManager.GetComponentData<FactionResources>(faction);
+
+            Assert.AreEqual(95f, businessAfter.Credits, 1e-3f);
+            Assert.AreEqual(5f, factionAfter.Credits, 1e-3f);
+        }
+
+        private Entity CreateFaction(ushort factionId, FactionOutlook outlook, float startingCredits = 0f)
+        {
+            var faction = _entityManager.CreateEntity(typeof(Space4XFaction), typeof(FactionResources));
+            _entityManager.SetComponentData(faction, Space4XFaction.Empire(factionId, outlook));
+            _entityManager.SetComponentData(faction, new FactionResources
+            {
+                Credits = startingCredits,
+                Materials = 0f,
+                Energy = 0f,
+                Influence = 0f,
+                Research = 0f,
+                IncomeRate = 0f,
+                ExpenseRate = 0f
+            });
+            return faction;
+        }
+
+        private void ConfigurePolicy(
+            Entity faction,
+            Space4XTaxProfileSource source,
+            float baseRate,
+            float lawWeight,
+            float integrityWeight,
+            float businessAssetRate,
+            float exemption = 0f)
+        {
+            _entityManager.AddComponentData(faction, new Space4XTaxPolicy
+            {
+                Enabled = 1,
+                CollectionIntervalTicks = 1u,
+                ProfileSource = source,
+                SocietyBlendWeight01 = (half)0.5f,
+                BaseRate01 = (half)baseRate,
+                MinRate01 = (half)0f,
+                MaxRate01 = (half)1f,
+                LawfulnessRateWeight01 = (half)lawWeight,
+                IntegrityRateWeight01 = (half)integrityWeight,
+                AuthoritarianRateBias01 = (half)0f,
+                EgalitarianRateBias01 = (half)0f,
+                BaseLeakRate01 = (half)0f,
+                CorruptLeakBonus01 = (half)0f,
+                BusinessAssetTaxRate01 = (half)businessAssetRate,
+                BusinessCreditsExemption = exemption
+            });
+
+            _entityManager.AddComponentData(faction, new Space4XTaxRuntime
+            {
+                LastCollectionTick = 0u,
+                LastCollectedCredits = 0f,
+                LastLeakageCredits = 0f,
+                LastEffectiveRate01 = 0f,
+                LastProfileLaw = 0f,
+                LastProfileIntegrity = 0f,
+                LastTaxpayerCount = 0u,
+                TotalCollectedCredits = 0f,
+                TotalLeakageCredits = 0f
+            });
+
+            var bands = _entityManager.AddBuffer<Space4XTaxBand>(faction);
+            bands.Add(new Space4XTaxBand
+            {
+                MinIncomePerTick = 0f,
+                MaxIncomePerTick = 0f,
+                RateOffset01 = (half)0f
+            });
+        }
+    }
+}
+#endif
+


### PR DESCRIPTION
## Summary\n- packages recent laptop stashes into mergeable commits from origin/main\n- includes status-event payload enrichment in area effects\n- includes leisure education facilities + morale/progression hooks + tests\n- includes Space4X tax policy/runtime system + tests\n\n## Validation (laptop mini)\n- ran headless Unity compile pass (-batchmode -quit) on this branch\n- compile still fails with broad baseline dependency/namespace errors unrelated to this stash pack (see mini_validate_space4x.log)\n\n## Why\n- clears stash debt into reviewable history so desktop can merge safely and continue iteration without hidden local state.